### PR TITLE
Add assigned tickets to the home screen

### DIFF
--- a/Sluggo.xcodeproj/project.pbxproj
+++ b/Sluggo.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		7D23834B264119050091C7E8 /* HomeTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D23834A264119050091C7E8 /* HomeTableViewController.swift */; };
 		7D53BE6926433D6600400D0E /* PinnedTicketManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D53BE6826433D6600400D0E /* PinnedTicketManager.swift */; };
 		7D778C06264A374C00D4061A /* ViewControllerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D778C05264A374C00D4061A /* ViewControllerExtensions.swift */; };
+		7D778C0A264A6A0F00D4061A /* TicketManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D778C09264A6A0F00D4061A /* TicketManagerTests.swift */; };
 		7D9963A6261EF3A4002338E7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D9963A5261EF3A4002338E7 /* AppDelegate.swift */; };
 		7D9963AD261EF3A4002338E7 /* Root.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7D9963AB261EF3A4002338E7 /* Root.storyboard */; };
 		7D9963B2261EF3A5002338E7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7D9963B1261EF3A5002338E7 /* Assets.xcassets */; };
@@ -118,6 +119,7 @@
 		7D23834A264119050091C7E8 /* HomeTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeTableViewController.swift; path = "Sluggo/View Controllers/HomeTableViewController.swift"; sourceTree = SOURCE_ROOT; };
 		7D53BE6826433D6600400D0E /* PinnedTicketManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedTicketManager.swift; sourceTree = "<group>"; };
 		7D778C05264A374C00D4061A /* ViewControllerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerExtensions.swift; sourceTree = "<group>"; };
+		7D778C09264A6A0F00D4061A /* TicketManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketManagerTests.swift; sourceTree = "<group>"; };
 		7D9963A2261EF3A4002338E7 /* Sluggo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sluggo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D9963A5261EF3A4002338E7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7D9963AC261EF3A4002338E7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Root.storyboard; sourceTree = "<group>"; };
@@ -276,6 +278,7 @@
 				7D1354FB262D026E00D38EE0 /* UserTests.swift */,
 				2FEF5DAD262D1C4900434763 /* MemberTests.swift */,
 				2F44E21C2639FA6B006CA85D /* TicketTests.swift */,
+				7D778C09264A6A0F00D4061A /* TicketManagerTests.swift */,
 			);
 			path = SluggoTests;
 			sourceTree = "<group>";
@@ -508,6 +511,7 @@
 				7D1354FC262D026E00D38EE0 /* UserTests.swift in Sources */,
 				2FEF5DAE262D1C4900434763 /* MemberTests.swift in Sources */,
 				7D9963C0261EF3A5002338E7 /* SluggoTests.swift in Sources */,
+				7D778C0A264A6A0F00D4061A /* TicketManagerTests.swift in Sources */,
 				2F44E21D2639FA6B006CA85D /* TicketTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sluggo.xcodeproj/project.pbxproj
+++ b/Sluggo.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		7D1DA6B7262B866D00E7C12D /* SidebarData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D1DA6B6262B866D00E7C12D /* SidebarData.swift */; };
 		7D23834B264119050091C7E8 /* HomeTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D23834A264119050091C7E8 /* HomeTableViewController.swift */; };
 		7D53BE6926433D6600400D0E /* PinnedTicketManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D53BE6826433D6600400D0E /* PinnedTicketManager.swift */; };
+		7D778C06264A374C00D4061A /* ViewControllerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D778C05264A374C00D4061A /* ViewControllerExtensions.swift */; };
 		7D9963A6261EF3A4002338E7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D9963A5261EF3A4002338E7 /* AppDelegate.swift */; };
 		7D9963AD261EF3A4002338E7 /* Root.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7D9963AB261EF3A4002338E7 /* Root.storyboard */; };
 		7D9963B2261EF3A5002338E7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7D9963B1261EF3A5002338E7 /* Assets.xcassets */; };
@@ -116,6 +117,7 @@
 		7D1DA6B6262B866D00E7C12D /* SidebarData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarData.swift; sourceTree = "<group>"; };
 		7D23834A264119050091C7E8 /* HomeTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HomeTableViewController.swift; path = "Sluggo/View Controllers/HomeTableViewController.swift"; sourceTree = SOURCE_ROOT; };
 		7D53BE6826433D6600400D0E /* PinnedTicketManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedTicketManager.swift; sourceTree = "<group>"; };
+		7D778C05264A374C00D4061A /* ViewControllerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerExtensions.swift; sourceTree = "<group>"; };
 		7D9963A2261EF3A4002338E7 /* Sluggo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Sluggo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D9963A5261EF3A4002338E7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7D9963AC261EF3A4002338E7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Root.storyboard; sourceTree = "<group>"; };
@@ -223,6 +225,14 @@
 			path = Managers;
 			sourceTree = "<group>";
 		};
+		7D778C04264A374200D4061A /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				7D778C05264A374C00D4061A /* ViewControllerExtensions.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		7D996399261EF3A4002338E7 = {
 			isa = PBXGroup;
 			children = (
@@ -296,6 +306,7 @@
 		7DC2A2202629442B0002CEE6 /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				7D778C04264A374200D4061A /* Extensions */,
 				0522586F2636100B00B49CE4 /* LaunchViewController.swift */,
 				5A79FFE5262E563F00D04320 /* LoginViewController.swift */,
 				7D1DA6AD262B82C200E7C12D /* RootViewController.swift */,
@@ -477,6 +488,7 @@
 				7D9963A6261EF3A4002338E7 /* AppDelegate.swift in Sources */,
 				5A673570263BF2D200C4C778 /* UIColor.swift in Sources */,
 				3A150A6C26365B670052934B /* TagRecord.swift in Sources */,
+				7D778C06264A374C00D4061A /* ViewControllerExtensions.swift in Sources */,
 				7D23834B264119050091C7E8 /* HomeTableViewController.swift in Sources */,
 				5AB1C8EF262FE3210010F85E /* TagManager.swift in Sources */,
 				5A9FF88E26386D4700378550 /* TicketListController.swift in Sources */,

--- a/Sluggo/Models/Exceptions.swift
+++ b/Sluggo/Models/Exceptions.swift
@@ -50,4 +50,8 @@ extension UIAlertController {
         
         vc.present(alertController, animated: true, completion: nil)
     }
+    
+    static func createAndPresentError(vc: UIViewController, error: Error) {
+        UIAlertController.createAndPresentError(vc: vc, error: error, completion: nil)
+    }
 }

--- a/Sluggo/Models/Managers/TicketManager.swift
+++ b/Sluggo/Models/Managers/TicketManager.swift
@@ -19,16 +19,16 @@ class TicketManager {
         return URL(string: identity.baseAddress + TeamManager.urlBase + "\(identity.team!.id)" + TicketManager.urlBase + "\(ticketRecord.id)/")!
     }
     
-    private func makeListUrl(page: Int, assignedMember: MemberRecord?) -> URL {
+    public func makeListUrl(page: Int, assignedMember: MemberRecord?) -> URL {
         var urlString = identity.baseAddress + TeamManager.urlBase + "\(identity.team!.id)" + TicketManager.urlBase + "?page=\(page)"
         if let assignedMember = assignedMember {
-            urlString += "?assigned_user__owner_username=\(assignedMember.owner.username)"
+            urlString += "&assigned_user__owner__username=\(assignedMember.owner.username)"
         }
         return URL(string: urlString)!
     }
     
     public func listTeamTickets(page: Int, assigned: MemberRecord?, completionHandler: @escaping (Result<PaginatedList<TicketRecord>, Error>) -> Void) -> Void {
-        let requestBuilder = URLRequestBuilder(url: makeListUrl(page: page, assignedMember: nil))
+        let requestBuilder = URLRequestBuilder(url: makeListUrl(page: page, assignedMember: assigned))
             .setMethod(method: .GET)
             .setIdentity(identity: self.identity)
         

--- a/Sluggo/Models/Managers/TicketManager.swift
+++ b/Sluggo/Models/Managers/TicketManager.swift
@@ -19,17 +19,24 @@ class TicketManager {
         return URL(string: identity.baseAddress + TeamManager.urlBase + "\(identity.team!.id)" + TicketManager.urlBase + "\(ticketRecord.id)/")!
     }
     
-    private func makeListUrl(page: Int) -> URL {
-        let urlString = identity.baseAddress + TeamManager.urlBase + "\(identity.team!.id)" + TicketManager.urlBase + "?page=\(page)"
+    private func makeListUrl(page: Int, assignedMember: MemberRecord?) -> URL {
+        var urlString = identity.baseAddress + TeamManager.urlBase + "\(identity.team!.id)" + TicketManager.urlBase + "?page=\(page)"
+        if let assignedMember = assignedMember {
+            urlString += "?assigned_user__owner_username=\(assignedMember.owner.username)"
+        }
         return URL(string: urlString)!
     }
     
-    public func listTeamTickets(page: Int, completionHandler: @escaping (Result<PaginatedList<TicketRecord>, Error>) -> Void) -> Void {
-        let requestBuilder = URLRequestBuilder(url: makeListUrl(page: page))
+    public func listTeamTickets(page: Int, assigned: MemberRecord?, completionHandler: @escaping (Result<PaginatedList<TicketRecord>, Error>) -> Void) -> Void {
+        let requestBuilder = URLRequestBuilder(url: makeListUrl(page: page, assignedMember: nil))
             .setMethod(method: .GET)
             .setIdentity(identity: self.identity)
         
         JsonLoader.executeCodableRequest(request: requestBuilder.getRequest(), completionHandler: completionHandler)
+    }
+    
+    public func listTeamTickets(page: Int, completionHandler: @escaping (Result<PaginatedList<TicketRecord>, Error>) -> Void) -> Void {
+        listTeamTickets(page: page, assigned: nil, completionHandler: completionHandler)
     }
     
     public func makeTicket(ticket: WriteTicketRecord, completionHandler: @escaping(Result<TicketRecord, Error>) -> Void)->Void{
@@ -37,7 +44,7 @@ class TicketManager {
             completionHandler(.failure(Exception.runtimeError(message: "Failed to serialize ticket JSON for makeTicket in TicketManager")))
             return
         }
-        let requestBuilder = URLRequestBuilder(url: makeListUrl(page: 1))
+        let requestBuilder = URLRequestBuilder(url: makeListUrl(page: 1, assignedMember: nil))
             .setMethod(method: .POST)
             .setData(data: body)
             .setIdentity(identity: self.identity)

--- a/Sluggo/View Controllers/Extensions/ViewControllerExtensions.swift
+++ b/Sluggo/View Controllers/Extensions/ViewControllerExtensions.swift
@@ -1,0 +1,45 @@
+//
+//  ViewControllerExtensions.swift
+//  Sluggo
+//
+//  Created by Isaac Trimble-Pederson on 5/10/21.
+//
+
+import UIKit
+
+extension UIViewController {
+    func presentError(error: Error, completion: ((UIAlertAction) -> Void)?) {
+        UIAlertController.createAndPresentError(vc: self, error: error, completion: completion)
+    }
+    
+    func presentError(error: Error) {
+        UIAlertController.createAndPresentError(vc: self, error: error)
+    }
+    
+    func processResult<T>(result: Result<T, Error>,  onSuccess: @escaping ((T) -> Void),  onError: ((Error) -> Void)?,  after: (() -> Void)?) {
+        DispatchQueue.main.sync {
+            switch(result) {
+            case .success(let successObj):
+                onSuccess(successObj)
+                break
+            case .failure(let error):
+                if let errorHandler = onError {
+                    errorHandler(error)
+                } else {
+                    presentError(error: error)
+                }
+            }
+            
+            // Continue chains if necessary
+            after?()
+        }
+    }
+    
+    func processResult<T>(result: Result<T, Error>, onSuccess: @escaping ((T) -> Void), after: (() -> Void)?) {
+        self.processResult(result: result, onSuccess: onSuccess, onError: nil, after: after)
+    }
+    
+    func processResult<T>(result: Result<T, Error>, onSuccess: @escaping ((T) -> Void)) {
+        self.processResult(result: result, onSuccess: onSuccess, onError: nil, after: nil)
+    }
+}

--- a/Sluggo/View Controllers/HomeTableViewController.swift
+++ b/Sluggo/View Controllers/HomeTableViewController.swift
@@ -65,7 +65,13 @@ class HomeTableViewController: UITableViewController {
     }
     
     func loadAssignedTickets(completionHandler: (() -> Void)?) {
-        // TODO
+        // Note: This will only grab the first page.
+        // This is an OK assumption, since we assume the total page size is > 3.
+        // Ideally, this could be extended with some other endpoints to get the total counts
+        // but this will suffice for now
+        let ticketsManager = TicketManager(identity)
+        // TODO Call to filtered method
+        
         completionHandler?()
     }
     

--- a/SluggoTests/TicketManagerTests.swift
+++ b/SluggoTests/TicketManagerTests.swift
@@ -1,0 +1,44 @@
+//
+//  TicketManagerTests.swift
+//  SluggoTests
+//
+//  Created by Isaac Trimble-Pederson on 5/11/21.
+//
+
+import XCTest
+@testable import Sluggo
+
+class TicketManagerTests: XCTestCase {
+    var identity: AppIdentity!
+    var exampleUser: UserRecord!
+    var exampleMember: MemberRecord!
+    
+    override func setUp() {
+        let team = TeamRecord(id: 1, name: "bugslotics", object_uuid: UUID(), ticket_head: 1, created: Date(timeIntervalSince1970: 0), activated: nil, deactivated: nil)
+        
+        identity = AppIdentity()
+        identity.team = team
+        identity.baseAddress = Constants.Config.URL_BASE
+        
+        exampleUser = UserRecord(id: 1, email: "sammy@ucsc.edu", first_name: "Sammy", last_name: "Slug", username: "sammytheslug")
+        exampleMember = MemberRecord(id: UUID().uuidString, owner: exampleUser, team_id: 1, object_uuid: UUID(), role: "AD", bio: nil, created: Date(timeIntervalSince1970: 0), activated: nil, deactivated: nil)
+    }
+
+    func testListURLGeneration() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        
+        let ticketManager = TicketManager(identity)
+        let obtainedURL = ticketManager.makeListUrl(page: 1, assignedMember: nil)
+        
+        XCTAssertEqual(obtainedURL, URL(string: "http://127.0.0.1:8000/api/teams/1/tickets/?page=1")!)
+    }
+    
+    func testListURLGenerationWithAssignedFilter() throws {
+        let ticketManager = TicketManager(identity)
+        let obtainedURL = ticketManager.makeListUrl(page: 1, assignedMember: exampleMember)
+        
+        XCTAssertEqual(obtainedURL, URL(string: "http://127.0.0.1:8000/api/teams/1/tickets/?page=1&assigned_user__owner__username=sammytheslug"))
+    }
+
+}

--- a/SluggoTests/TicketTests.swift
+++ b/SluggoTests/TicketTests.swift
@@ -45,16 +45,18 @@ class TicketTests: XCTestCase {
             "activated": "2021-04-28T20:24:15+0000",
             "deactivated": null
         },
+        "status": null,
         "title": "Hi",
         "description": "this is a description",
+        "due_date": null,
         "created": "2021-04-28T20:31:43+0000",
         "activated": "2021-04-28T20:31:43+0000",
+        "deactivated": null
     }
     """
     
     func testTicketDoesDeserialize() {
         // CRASHES, PLEASE FIX!
-        // you break it, you buy it
         let ticket: TicketRecord? = JsonLoader.decode(data: testWorkingJson.data(using: .utf8)!)
 
         XCTAssertNotNil(ticket)

--- a/SluggoTests/TicketTests.swift
+++ b/SluggoTests/TicketTests.swift
@@ -55,20 +55,20 @@ class TicketTests: XCTestCase {
     """
     
     func testTicketDoesDeserialize() {
-
-        let ticket: TicketRecord? = JsonLoader.decode(data: testWorkingJson.data(using: .utf8)!)
-        
-        XCTAssertNotNil(ticket)
-        
-        XCTAssertEqual(ticket!.ticket_number, 2)
-        XCTAssertEqual(ticket!.title, "Hi")
-        XCTAssertEqual(ticket!.id, 2)
-        
-        
-        XCTAssertNil(ticket!.status)
-        XCTAssertNil(ticket!.assigned_user)
-
-        
+        // CRASHES, PLEASE FIX!
+//        let ticket: TicketRecord? = JsonLoader.decode(data: testWorkingJson.data(using: .utf8)!)
+//
+//        XCTAssertNotNil(ticket)
+//
+//        XCTAssertEqual(ticket!.ticket_number, 2)
+//        XCTAssertEqual(ticket!.title, "Hi")
+//        XCTAssertEqual(ticket!.id, 2)
+//
+//
+//        XCTAssertNil(ticket!.status)
+//        XCTAssertNil(ticket!.assigned_user)
+//
+//
     }
     
     func testTicketDeserializesWithExtraProps() {
@@ -110,7 +110,7 @@ class TicketTests: XCTestCase {
     
     func testTicketDoesSerialize() {
         
-        let ticket = TicketRecord(id: 1, ticket_number: 1, tag_list: nil, object_uuid: UUID(uuidString: "aa80fe7c-d346-4944-9d9e-3d7286fc4ca7")!, assigned_user: nil, status: nil, title: "Howdy Partner", description: "This is a ticket", due_date: Date(), created: Date(), activated: Date(), deactivated: Date())
+        let ticket = TicketRecord(id: 1, ticket_number: 1, tag_list: [], object_uuid: UUID(uuidString: "aa80fe7c-d346-4944-9d9e-3d7286fc4ca7")!, assigned_user: nil, status: nil, title: "Howdy Partner", description: "This is a ticket", due_date: Date(), created: Date(), activated: Date(), deactivated: Date())
         
         let json = JsonLoader.encode(object: ticket)
         XCTAssertNotNil(json)

--- a/SluggoTests/TicketTests.swift
+++ b/SluggoTests/TicketTests.swift
@@ -14,6 +14,7 @@ class TicketTests: XCTestCase {
         "id": 2,
         "ticket_number": 2,
         "object_uuid": "cefdf703-40ff-40d0-b07a-1583cc33d7d4",
+        "tag_list": [],
         "title": "Hi",
         "description": "this is a description",
         "created": "2021-04-28T20:31:43+0000",
@@ -44,31 +45,29 @@ class TicketTests: XCTestCase {
             "activated": "2021-04-28T20:24:15+0000",
             "deactivated": null
         },
-        "status": null,
         "title": "Hi",
         "description": "this is a description",
-        "due_date": null,
         "created": "2021-04-28T20:31:43+0000",
         "activated": "2021-04-28T20:31:43+0000",
-        "deactivated": null
     }
     """
     
     func testTicketDoesDeserialize() {
         // CRASHES, PLEASE FIX!
-//        let ticket: TicketRecord? = JsonLoader.decode(data: testWorkingJson.data(using: .utf8)!)
-//
-//        XCTAssertNotNil(ticket)
-//
-//        XCTAssertEqual(ticket!.ticket_number, 2)
-//        XCTAssertEqual(ticket!.title, "Hi")
-//        XCTAssertEqual(ticket!.id, 2)
-//
-//
-//        XCTAssertNil(ticket!.status)
-//        XCTAssertNil(ticket!.assigned_user)
-//
-//
+        // you break it, you buy it
+        let ticket: TicketRecord? = JsonLoader.decode(data: testWorkingJson.data(using: .utf8)!)
+
+        XCTAssertNotNil(ticket)
+
+        XCTAssertEqual(ticket!.ticket_number, 2)
+        XCTAssertEqual(ticket!.title, "Hi")
+        XCTAssertEqual(ticket!.id, 2)
+
+
+        XCTAssertNil(ticket!.status)
+        XCTAssertNil(ticket!.assigned_user)
+
+
     }
     
     func testTicketDeserializesWithExtraProps() {


### PR DESCRIPTION
This PR adds assigned tickets to the home screen of the app.

This also adds some additional features, such as revamping the homepage error flow to be more robust, and migrating handling result calls to a new abstraction in a ViewController extension.