### PR TITLE
Added basic member tab and associated list

### DIFF
--- a/Sluggo.xcodeproj/project.pbxproj
+++ b/Sluggo.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		051AAB0B2630FD6500BCB9C7 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051AAB0A2630FD6500BCB9C7 /* Constants.swift */; };
 		052258702636100B00B49CE4 /* LaunchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0522586F2636100B00B49CE4 /* LaunchViewController.swift */; };
+		05588A12264DB61E000D8674 /* TeamMembers.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 05588A11264DB61E000D8674 /* TeamMembers.storyboard */; };
+		05588A1A264DBDAB000D8674 /* MemberListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05588A19264DBDAB000D8674 /* MemberListViewController.swift */; };
 		2F2247AC262920AC006C6EE6 /* TokenRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2247AB262920AC006C6EE6 /* TokenRecord.swift */; };
 		2F3AD7A32627C86A00B61A97 /* UserRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3AD7A22627C86A00B61A97 /* UserRecord.swift */; };
 		2F3AD7A82627C89B00B61A97 /* MemberRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3AD7A72627C89B00B61A97 /* MemberRecord.swift */; };
@@ -81,6 +83,8 @@
 /* Begin PBXFileReference section */
 		051AAB0A2630FD6500BCB9C7 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		0522586F2636100B00B49CE4 /* LaunchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewController.swift; sourceTree = "<group>"; };
+		05588A11264DB61E000D8674 /* TeamMembers.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TeamMembers.storyboard; sourceTree = "<group>"; };
+		05588A19264DBDAB000D8674 /* MemberListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberListViewController.swift; sourceTree = "<group>"; };
 		2F2247AB262920AC006C6EE6 /* TokenRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRecord.swift; sourceTree = "<group>"; };
 		2F3AD7A22627C86A00B61A97 /* UserRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRecord.swift; sourceTree = "<group>"; };
 		2F3AD7A72627C89B00B61A97 /* MemberRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberRecord.swift; sourceTree = "<group>"; };
@@ -302,6 +306,7 @@
 				5A9FF88826386D1400378550 /* Ticket.storyboard */,
 				7DEA17842639E7B5004E5A71 /* LaunchScreen.storyboard */,
 				3A150A76263CB5F70052934B /* TicketDetail.storyboard */,
+				05588A11264DB61E000D8674 /* TeamMembers.storyboard */,
 			);
 			path = Storyboards;
 			sourceTree = "<group>";
@@ -312,13 +317,14 @@
 				7D778C04264A374200D4061A /* Extensions */,
 				0522586F2636100B00B49CE4 /* LaunchViewController.swift */,
 				5A79FFE5262E563F00D04320 /* LoginViewController.swift */,
+				5A9C4C202641113D00B270AB /* TeamSelectorContainerViewController.swift */,
+				5A9C4C1B2640BC4E00B270AB /* TeamTableViewController.swift */,
 				7D1DA6AD262B82C200E7C12D /* RootViewController.swift */,
 				7DC2A226262948800002CEE6 /* SluggoSidebarContainerViewController.swift */,
-				5A9FF88D26386D4700378550 /* TicketListController.swift */,
 				7D23834A264119050091C7E8 /* HomeTableViewController.swift */,
+				5A9FF88D26386D4700378550 /* TicketListController.swift */,
 				3A150A7E263CBA860052934B /* TicketDetailViewController.swift */,
-				5A9C4C1B2640BC4E00B270AB /* TeamTableViewController.swift */,
-				5A9C4C202641113D00B270AB /* TeamSelectorContainerViewController.swift */,
+				05588A19264DBDAB000D8674 /* MemberListViewController.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -435,6 +441,7 @@
 				7D9963B2261EF3A5002338E7 /* Assets.xcassets in Resources */,
 				5A9FF88926386D1400378550 /* Ticket.storyboard in Resources */,
 				5A79FFE1262E562A00D04320 /* Main.storyboard in Resources */,
+				05588A12264DB61E000D8674 /* TeamMembers.storyboard in Resources */,
 				7D9963AD261EF3A4002338E7 /* Root.storyboard in Resources */,
 				7DEA17852639E7B5004E5A71 /* LaunchScreen.storyboard in Resources */,
 				3A150A77263CB5F70052934B /* TicketDetail.storyboard in Resources */,
@@ -473,6 +480,7 @@
 				2FD70D5D2636144300D13C75 /* LogoutMessage.swift in Sources */,
 				5AB1C8EA262FE2EF0010F85E /* MemberManager.swift in Sources */,
 				5A9C4C1C2640BC4E00B270AB /* TeamTableViewController.swift in Sources */,
+				05588A1A264DBDAB000D8674 /* MemberListViewController.swift in Sources */,
 				2F3AD7AD2627C8EF00B61A97 /* TeamRecord.swift in Sources */,
 				7DC54AE526437AB3000C8300 /* PinnedTicketRecord.swift in Sources */,
 				7DC2A227262948800002CEE6 /* SluggoSidebarContainerViewController.swift in Sources */,

--- a/Sluggo.xcodeproj/project.pbxproj
+++ b/Sluggo.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		051AAB0B2630FD6500BCB9C7 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051AAB0A2630FD6500BCB9C7 /* Constants.swift */; };
 		052258702636100B00B49CE4 /* LaunchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0522586F2636100B00B49CE4 /* LaunchViewController.swift */; };
 		05588A12264DB61E000D8674 /* TeamMembers.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 05588A11264DB61E000D8674 /* TeamMembers.storyboard */; };
-		05588A1A264DBDAB000D8674 /* MemberListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05588A19264DBDAB000D8674 /* MemberListViewController.swift */; };
+		05DE0CD7264F11E400D69C61 /* MemberListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */; };
 		2F2247AC262920AC006C6EE6 /* TokenRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2247AB262920AC006C6EE6 /* TokenRecord.swift */; };
 		2F3AD7A32627C86A00B61A97 /* UserRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3AD7A22627C86A00B61A97 /* UserRecord.swift */; };
 		2F3AD7A82627C89B00B61A97 /* MemberRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3AD7A72627C89B00B61A97 /* MemberRecord.swift */; };
@@ -92,7 +92,7 @@
 		051AAB0A2630FD6500BCB9C7 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		0522586F2636100B00B49CE4 /* LaunchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewController.swift; sourceTree = "<group>"; };
 		05588A11264DB61E000D8674 /* TeamMembers.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TeamMembers.storyboard; sourceTree = "<group>"; };
-		05588A19264DBDAB000D8674 /* MemberListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberListViewController.swift; sourceTree = "<group>"; };
+		05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemberListViewController.swift; sourceTree = "<group>"; };
 		2F2247AB262920AC006C6EE6 /* TokenRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRecord.swift; sourceTree = "<group>"; };
 		2F3AD7A22627C86A00B61A97 /* UserRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRecord.swift; sourceTree = "<group>"; };
 		2F3AD7A72627C89B00B61A97 /* MemberRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberRecord.swift; sourceTree = "<group>"; };
@@ -348,16 +348,15 @@
 				7D778C04264A374200D4061A /* Extensions */,
 				0522586F2636100B00B49CE4 /* LaunchViewController.swift */,
 				5A79FFE5262E563F00D04320 /* LoginViewController.swift */,
+				7D1DA6AD262B82C200E7C12D /* RootViewController.swift */,
 				5A9C4C202641113D00B270AB /* TeamSelectorContainerViewController.swift */,
 				5A9C4C1B2640BC4E00B270AB /* TeamTableViewController.swift */,
-				7D1DA6AD262B82C200E7C12D /* RootViewController.swift */,
 				7DC2A226262948800002CEE6 /* SluggoSidebarContainerViewController.swift */,
+				7D23834A264119050091C7E8 /* HomeTableViewController.swift */,
 				5A9FF88D26386D4700378550 /* TicketListController.swift */,
 				3A150A7E263CBA860052934B /* TicketDetailViewController.swift */,
-				5A9C4C1B2640BC4E00B270AB /* TeamTableViewController.swift */,
-				5A9C4C202641113D00B270AB /* TeamSelectorContainerViewController.swift */,
-				7D23834A264119050091C7E8 /* HomeTableViewController.swift */,
 				5A25CFAB264B966300852035 /* TicketFilterTableViewController.swift */,
+				05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -516,7 +515,6 @@
 				2FD70D5D2636144300D13C75 /* LogoutMessage.swift in Sources */,
 				5AB1C8EA262FE2EF0010F85E /* MemberManager.swift in Sources */,
 				5A9C4C1C2640BC4E00B270AB /* TeamTableViewController.swift in Sources */,
-				05588A1A264DBDAB000D8674 /* MemberListViewController.swift in Sources */,
 				2F3AD7AD2627C8EF00B61A97 /* TeamRecord.swift in Sources */,
 				7DC54AE526437AB3000C8300 /* PinnedTicketRecord.swift in Sources */,
 				7DC2A227262948800002CEE6 /* SluggoSidebarContainerViewController.swift in Sources */,
@@ -532,6 +530,7 @@
 				5A25CFF1264BE28100852035 /* HasTitle.swift in Sources */,
 				7D53BE6926433D6600400D0E /* PinnedTicketManager.swift in Sources */,
 				5ACC0F062630CA2700DCF83E /* Exceptions.swift in Sources */,
+				05DE0CD7264F11E400D69C61 /* MemberListViewController.swift in Sources */,
 				5A25CFA7264B934400852035 /* StatusManager.swift in Sources */,
 				5AB1C8F7262FE3520010F85E /* AppIdentity.swift in Sources */,
 				7D9963A6261EF3A4002338E7 /* AppDelegate.swift in Sources */,

--- a/Sluggo/Storyboards/Base.lproj/Root.storyboard
+++ b/Sluggo/Storyboards/Base.lproj/Root.storyboard
@@ -74,7 +74,7 @@
                     </connections>
                 </swipeGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="-1362.3188405797102" y="456.69642857142856"/>
+            <point key="canvasLocation" x="-1377" y="459"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="L3t-1S-G5L">
@@ -88,11 +88,12 @@
                     <connections>
                         <segue destination="wOi-Vq-YT9" kind="relationship" relationship="viewControllers" id="uhx-Dl-tdo"/>
                         <segue destination="Ymv-15-4Ny" kind="relationship" relationship="viewControllers" id="h5V-Lf-pAj"/>
+                        <segue destination="TSs-vk-uIV" kind="relationship" relationship="viewControllers" id="TI1-M8-elF"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0VU-E0-E3L" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-268" y="271"/>
+            <point key="canvasLocation" x="-342" y="185"/>
         </scene>
         <!--Home-->
         <scene sceneID="R6k-Kr-4Yi">
@@ -103,7 +104,7 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iZa-AI-9Cc" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="639" y="35"/>
+            <point key="canvasLocation" x="639" y="-38"/>
         </scene>
         <!--Ticket-->
         <scene sceneID="3Ws-rC-SDg">
@@ -113,7 +114,17 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="D7p-qD-AwA" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="641" y="317"/>
+            <point key="canvasLocation" x="639" y="185"/>
+        </scene>
+        <!--TeamMembers-->
+        <scene sceneID="tWt-KY-9v9">
+            <objects>
+                <viewControllerPlaceholder storyboardName="TeamMembers" id="TSs-vk-uIV" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item" id="i5O-Gp-5TO"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="JSt-6f-4tf" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="625" y="415"/>
         </scene>
     </scenes>
     <resources>

--- a/Sluggo/Storyboards/TeamMembers.storyboard
+++ b/Sluggo/Storyboards/TeamMembers.storyboard
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="E8f-aG-d2W">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Team Members-->
+        <scene sceneID="krp-Q7-Pki">
+            <objects>
+                <tableViewController id="FqQ-D1-h4d" customClass="MemberListViewController" customModule="Sluggo" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="Ayv-a3-gOC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MemberCell" id="WSC-FE-HFz">
+                                <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="WSC-FE-HFz" id="n3f-4p-LAd">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="FqQ-D1-h4d" id="shd-X2-QVd"/>
+                            <outlet property="delegate" destination="FqQ-D1-h4d" id="NBe-HV-TRm"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Team Members" id="57K-sf-05P"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="lM2-wd-7gl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="425" y="-163"/>
+        </scene>
+        <!--Members-->
+        <scene sceneID="ami-Zl-Jrs">
+            <objects>
+                <navigationController id="E8f-aG-d2W" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Members" image="person.2.fill" catalog="system" id="urg-qZ-4T3"/>
+                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="1QG-Aw-Qpg">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <toolbar key="toolbar" opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="T84-eZ-hDG">
+                        <autoresizingMask key="autoresizingMask"/>
+                    </toolbar>
+                    <connections>
+                        <segue destination="FqQ-D1-h4d" kind="relationship" relationship="rootViewController" destinationCreationSelector="createMembers:" id="Lrf-e0-gzf"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="UVw-P0-IyE" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-465" y="-163"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="person.2.fill" catalog="system" width="128" height="80"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Sluggo/View Controllers/MemberListViewController.swift
+++ b/Sluggo/View Controllers/MemberListViewController.swift
@@ -41,8 +41,6 @@ class MemberListViewController: UITableViewController {
         let member = self.members[indexPath.row]
         cell.textLabel?.text = member.owner.username
         
-        //cell.accessoryType = (member.owner.id == self.identity.authenticatedUser!.pk) ? .checkmark : .none
-        
         return cell
     }
     
@@ -73,36 +71,4 @@ class MemberListViewController: UITableViewController {
         }
     }
     
-//    private func loadData(page: Int) {
-//        let memberManager = MemberManager(identity: identity)
-//        
-//        memberManager.listFromTeams() { result in
-//            self.processResult(result: result, onSuccess: { record in
-//                self.maxNumber = record.count
-//            
-//                var membersCopy = Array(self.members)
-//                let pageOffset = (page - 1) * self.identity.pageSize
-//                
-//                if (pageOffset < self.members.count) {
-//                    membersCopy.removeSubrange(pageOffset...self.members.count-1)
-//                }
-//                
-//                for entry in record.results {
-//                    membersCopy.append(entry)
-//                }
-//            
-//                DispatchQueue.main.async {
-//                    self.refreshControl?.endRefreshing()
-//                    self.members = membersCopy
-//                    self.tableView.reloadData()
-//                    self.isFetching = false
-//                }
-//            }, onError: { error in
-//                DispatchQueue.main.async {
-//                    let alert = UIAlertController.errorController(error: error)
-//                    self.present(alert, animated: true, completion: nil)
-//                }
-//            }, after: nil)
-//        }
-//    }
 }

--- a/Sluggo/View Controllers/MemberListViewController.swift
+++ b/Sluggo/View Controllers/MemberListViewController.swift
@@ -1,0 +1,97 @@
+//
+//  MemberList.swift
+//  Sluggo
+//
+//  Created by Troy Ebert on 5/13/21.
+//
+import UIKit
+
+class MemberListViewController: UITableViewController {
+    var identity: AppIdentity!
+    private var maxNumber: Int = 0
+    private var fetchingMembers: [MemberRecord] = []
+    private var members: [MemberRecord] = []
+    private var isFetching  = false
+    
+    required init? (coder: NSCoder, identity: AppIdentity) {
+        self.identity = identity
+        super.init(coder: coder)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    override func viewDidLoad() {
+        self.configureRefreshControl()
+        self.handleRefreshAction()
+    }
+    
+    func configureRefreshControl() {
+        refreshControl = UIRefreshControl()
+        refreshControl?.addTarget(self, action: #selector(handleRefreshAction), for: .valueChanged)
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return members.count
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "MemberCell", for: indexPath) as UITableViewCell
+        let member = self.members[indexPath.row]
+        cell.textLabel?.text = member.owner.username
+        
+        //cell.accessoryType = (member.owner.id == self.identity.authenticatedUser!.pk) ? .checkmark : .none
+        
+        return cell
+    }
+    
+    
+    @objc func handleRefreshAction() {
+        // enter the critical section
+        // do not wait
+        if (isFetching) { return }
+        
+        isFetching = true
+        self.loadData(page: 1)
+    }
+    
+    private func loadData(page: Int) {
+        let memberManager = MemberManager(identity: identity)
+        memberManager.listTeamMembers() { result in
+            switch(result) {
+            case .success(let record):
+                self.maxNumber = record.count
+                
+                let pageOffset = (page - 1) * self.identity.pageSize
+                if (pageOffset < self.fetchingMembers.count) {
+                    self.fetchingMembers.removeSubrange(pageOffset...self.fetchingMembers.count-1)
+                }
+                
+                for entry in record.results {
+                    self.fetchingMembers.append(entry)
+                }
+                
+                if (self.fetchingMembers.count >= self.maxNumber) {
+                    DispatchQueue.main.async {
+                        self.refreshControl?.endRefreshing()
+                        self.members = Array(self.fetchingMembers)
+                        self.fetchingMembers.removeAll()
+                        self.tableView.reloadData()
+                        self.isFetching = false
+                    }
+                    return
+                } else {
+                    self.loadData(page: page + 1)
+                }
+                
+                break;
+            case .failure(let error):
+                DispatchQueue.main.async {
+                    let alert = UIAlertController.errorController(error: error)
+                    self.present(alert, animated: true, completion: nil)
+                }
+            }
+        }
+    }
+}

--- a/Sluggo/View Controllers/RootViewController.swift
+++ b/Sluggo/View Controllers/RootViewController.swift
@@ -59,6 +59,10 @@ class RootViewController: UIViewController {
         return TicketListController(coder: coder, identity: identity)
     }
     
+    @IBSegueAction func createMembers(_ coder: NSCoder) -> MemberListViewController? {
+        return MemberListViewController(coder: coder, identity: identity)
+    }
+    
     @IBAction func receivedGesture() {
         NotificationCenter.default.post(name: .onSidebarTrigger, object: self, userInfo: [Sidebar.USER_INFO_KEY: SidebarStatus.open])
     }


### PR DESCRIPTION
Added a team members tab to the RootViewController which segues to a list of all the members on the team, using Sam's method of doing so for tickets/home.

For the list I reused a lot of Sam's TeamTableViewController with some minor tweaks to the UI and it grabs members instead of teams. I did so using listTeamMembers() in the MemberManager. Members are displayed with their associated username.