### PR TITLE
Allow User to add tags to their tickets

### DIFF
--- a/Sluggo.xcodeproj/project.pbxproj
+++ b/Sluggo.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		3A150A6726365A9A0052934B /* StatusRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A150A6626365A9A0052934B /* StatusRecord.swift */; };
 		3A150A6C26365B670052934B /* TagRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A150A6B26365B670052934B /* TagRecord.swift */; };
 		3A150A77263CB5F70052934B /* TicketDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3A150A76263CB5F70052934B /* TicketDetail.storyboard */; };
+		3A90FBB12651CEED00BE4F5D /* TicketTagTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A90FBB02651CEED00BE4F5D /* TicketTagTableViewCell.swift */; };
+		3A90FBB32651D76900BE4F5D /* TicketTabTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A90FBB22651D76900BE4F5D /* TicketTabTableViewController.swift */; };
 		5A00A0142639EDEA0085C8C6 /* URLRequestBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A00A0132639EDEA0085C8C6 /* URLRequestBuilder.swift */; };
 		5A00A045263A34CC0085C8C6 /* TicketTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A00A044263A34CC0085C8C6 /* TicketTableViewCell.swift */; };
 		5A25CFA2264B8C8100852035 /* TagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A25CFA1264B8C8100852035 /* TagTests.swift */; };
@@ -106,6 +108,8 @@
 		3A150A6626365A9A0052934B /* StatusRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusRecord.swift; sourceTree = "<group>"; };
 		3A150A6B26365B670052934B /* TagRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagRecord.swift; sourceTree = "<group>"; };
 		3A150A76263CB5F70052934B /* TicketDetail.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TicketDetail.storyboard; sourceTree = "<group>"; };
+		3A90FBB02651CEED00BE4F5D /* TicketTagTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketTagTableViewCell.swift; sourceTree = "<group>"; };
+		3A90FBB22651D76900BE4F5D /* TicketTabTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketTabTableViewController.swift; sourceTree = "<group>"; };
 		5A00A0132639EDEA0085C8C6 /* URLRequestBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestBuilder.swift; sourceTree = "<group>"; };
 		5A00A044263A34CC0085C8C6 /* TicketTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TicketTableViewCell.swift; sourceTree = "<group>"; };
 		5A25CFA1264B8C8100852035 /* TagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTests.swift; sourceTree = "<group>"; };
@@ -208,6 +212,7 @@
 				5A00A044263A34CC0085C8C6 /* TicketTableViewCell.swift */,
 				5AC6458F26412F0C00F46137 /* TeamTableViewCell.swift */,
 				5A25CFE6264BD73D00852035 /* TicketFilterTableViewCell.swift */,
+				3A90FBB02651CEED00BE4F5D /* TicketTagTableViewCell.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -349,16 +354,14 @@
 				0522586F2636100B00B49CE4 /* LaunchViewController.swift */,
 				5A79FFE5262E563F00D04320 /* LoginViewController.swift */,
 				7D1DA6AD262B82C200E7C12D /* RootViewController.swift */,
-				5A9C4C202641113D00B270AB /* TeamSelectorContainerViewController.swift */,
-				5A9C4C1B2640BC4E00B270AB /* TeamTableViewController.swift */,
 				7DC2A226262948800002CEE6 /* SluggoSidebarContainerViewController.swift */,
-				7D23834A264119050091C7E8 /* HomeTableViewController.swift */,
 				5A9FF88D26386D4700378550 /* TicketListController.swift */,
 				5A9C4C1B2640BC4E00B270AB /* TeamTableViewController.swift */,
 				5A9C4C202641113D00B270AB /* TeamSelectorContainerViewController.swift */,
 				7D23834A264119050091C7E8 /* HomeTableViewController.swift */,
 				5A25CFAB264B966300852035 /* TicketFilterTableViewController.swift */,
 				2FF89023264BBAC600D50B69 /* TicketDetailTableViewController.swift */,
+				3A90FBB22651D76900BE4F5D /* TicketTabTableViewController.swift */,
 				05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */,
 			);
 			path = "View Controllers";
@@ -530,6 +533,7 @@
 				5A9C4C212641113D00B270AB /* TeamSelectorContainerViewController.swift in Sources */,
 				5A79FFE6262E563F00D04320 /* LoginViewController.swift in Sources */,
 				5AB1C8FC262FF1690010F85E /* TicketRecord.swift in Sources */,
+				3A90FBB32651D76900BE4F5D /* TicketTabTableViewController.swift in Sources */,
 				5A25CFDF264BCF2C00852035 /* TicketFilterParameters.swift in Sources */,
 				5A25CFE7264BD73D00852035 /* TicketFilterTableViewCell.swift in Sources */,
 				7D1DA6B7262B866D00E7C12D /* SidebarData.swift in Sources */,
@@ -551,6 +555,7 @@
 				2F3AD7A32627C86A00B61A97 /* UserRecord.swift in Sources */,
 				052258702636100B00B49CE4 /* LaunchViewController.swift in Sources */,
 				3A150A6726365A9A0052934B /* StatusRecord.swift in Sources */,
+				3A90FBB12651CEED00BE4F5D /* TicketTagTableViewCell.swift in Sources */,
 				5A25CFF1264BE28100852035 /* HasTitle.swift in Sources */,
 				7D53BE6926433D6600400D0E /* PinnedTicketManager.swift in Sources */,
 				5ACC0F062630CA2700DCF83E /* Exceptions.swift in Sources */,

--- a/Sluggo/Components/TicketTagTableViewCell.swift
+++ b/Sluggo/Components/TicketTagTableViewCell.swift
@@ -1,0 +1,23 @@
+//
+//  TicketTagTableViewCell.swift
+//  Sluggo
+//
+//  Created by Stephan Martin on 5/16/21.
+//
+
+import UIKit
+
+class TicketTagTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization Code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        super.accessoryType = selected ? .checkmark : .none
+        // configures the view for the selected state
+    }
+}

--- a/Sluggo/Storyboards/TicketDetail.storyboard
+++ b/Sluggo/Storyboards/TicketDetail.storyboard
@@ -275,6 +275,7 @@
                         <outlet property="rightButton" destination="Y0g-vW-zoO" id="Fmv-oR-rUF"/>
                         <outlet property="statusField" destination="Vd7-MX-zXP" id="n8a-fO-fIH"/>
                         <outlet property="tagLabel" destination="Vqw-Ya-YEt" id="Xtk-B3-vja"/>
+                        <outlet property="tagPlusButton" destination="FpC-hV-Akd" id="3DB-UR-Fte"/>
                         <outlet property="ticketDescription" destination="FXd-xc-Qdr" id="fjQ-Mz-iad"/>
                         <outlet property="ticketTitle" destination="83h-u0-wFT" id="LFG-F8-WNQ"/>
                     </connections>

--- a/Sluggo/Storyboards/TicketDetail.storyboard
+++ b/Sluggo/Storyboards/TicketDetail.storyboard
@@ -7,6 +7,61 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
+        <!--Tag View-->
+        <scene sceneID="6tB-L9-ohh">
+            <objects>
+                <tableViewController title="Tag View" id="d7Y-OP-dfq" customClass="TicketTabTableViewController" customModule="Sluggo" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" allowsMultipleSelection="YES" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="taG-lb-W5L">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="790"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="TagEntry" textLabel="wH1-y3-YAJ" style="IBUITableViewCellStyleDefault" id="Oot-b2-Zv7" customClass="TicketTagTableViewCell" customModule="Sluggo" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="49" width="390" height="43.666667938232422"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Oot-b2-Zv7" id="KzV-Tk-sLP">
+                                    <rect key="frame" x="0.0" y="0.0" width="390" height="43.666667938232422"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="wH1-y3-YAJ">
+                                            <rect key="frame" x="20" y="0.0" width="350" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="d7Y-OP-dfq" id="wjI-6Q-UXC"/>
+                            <outlet property="delegate" destination="d7Y-OP-dfq" id="SZA-vh-sJn"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Add Tags" id="fym-lY-Ad6"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Aj4-WD-EOW" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4288" y="-471"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="EFg-d1-5kE">
+            <objects>
+                <navigationController storyboardIdentifier="TagNavigationController" id="6xP-qZ-JY7" sceneMemberID="viewController">
+                    <modalPageSheetSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="wtK-0a-Qym">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="56"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="d7Y-OP-dfq" kind="relationship" relationship="rootViewController" id="lbc-DK-QLb"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="08X-uq-dCu" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3380" y="-471"/>
+        </scene>
         <!--Selected Ticket-->
         <scene sceneID="YJv-g9-Z06">
             <objects>
@@ -90,10 +145,50 @@
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
+                            <tableViewSection headerTitle="Tags" id="4ZL-nR-onc" userLabel="Tags">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="zrD-b2-DVz">
+                                        <rect key="frame" x="20" y="328.99999809265137" width="350" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zrD-b2-DVz" id="QOS-7M-75q">
+                                            <rect key="frame" x="0.0" y="0.0" width="350" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No Tags Selected" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vqw-Ya-YEt">
+                                                    <rect key="frame" x="10" y="5" width="305" height="34"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FpC-hV-Akd">
+                                                    <rect key="frame" x="320" y="5" width="20" height="34"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="20" id="wPQ-Xu-XVA"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                    <state key="normal" title="Add Tag Button" image="plus.app" catalog="system"/>
+                                                    <connections>
+                                                        <action selector="addTagButtonHit:" destination="tgi-Ip-0ok" eventType="touchUpInside" id="ZzW-au-l3d"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="Vqw-Ya-YEt" secondAttribute="bottom" constant="5" id="2Zl-8v-lLN"/>
+                                                <constraint firstAttribute="trailing" secondItem="FpC-hV-Akd" secondAttribute="trailing" constant="10" id="9XO-uJ-chc"/>
+                                                <constraint firstItem="FpC-hV-Akd" firstAttribute="top" secondItem="QOS-7M-75q" secondAttribute="top" constant="5" id="BNQ-6Q-6uv"/>
+                                                <constraint firstAttribute="bottom" secondItem="FpC-hV-Akd" secondAttribute="bottom" constant="5" id="TEv-5v-Mkq"/>
+                                                <constraint firstItem="Vqw-Ya-YEt" firstAttribute="top" secondItem="QOS-7M-75q" secondAttribute="top" constant="5" id="bEr-qL-oOQ"/>
+                                                <constraint firstItem="Vqw-Ya-YEt" firstAttribute="leading" secondItem="QOS-7M-75q" secondAttribute="leading" constant="10" id="fwV-Xq-kXq"/>
+                                                <constraint firstItem="FpC-hV-Akd" firstAttribute="leading" secondItem="Vqw-Ya-YEt" secondAttribute="trailing" constant="5" id="hqz-fo-Vfr"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
                             <tableViewSection headerTitle="Due Date" id="7Fz-6B-Bdk">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="lqy-U3-bas">
-                                        <rect key="frame" x="20" y="328.99999809265137" width="350" height="43.5"/>
+                                        <rect key="frame" x="20" y="422.66666412353516" width="350" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lqy-U3-bas" id="VL6-jI-WTv">
                                             <rect key="frame" x="0.0" y="0.0" width="350" height="43.5"/>
@@ -132,7 +227,7 @@
                             <tableViewSection headerTitle="Description" id="D4b-Jt-OFW">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="200" id="vfq-cT-bCM">
-                                        <rect key="frame" x="20" y="422.16666412353516" width="350" height="200"/>
+                                        <rect key="frame" x="20" y="515.83333015441895" width="350" height="200"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="vfq-cT-bCM" id="U8y-Kf-fmc">
                                             <rect key="frame" x="0.0" y="0.0" width="350" height="200"/>
@@ -179,6 +274,7 @@
                         <outlet property="navBar" destination="1gU-cG-gDW" id="9II-yC-yRc"/>
                         <outlet property="rightButton" destination="Y0g-vW-zoO" id="Fmv-oR-rUF"/>
                         <outlet property="statusField" destination="Vd7-MX-zXP" id="n8a-fO-fIH"/>
+                        <outlet property="tagLabel" destination="Vqw-Ya-YEt" id="Xtk-B3-vja"/>
                         <outlet property="ticketDescription" destination="FXd-xc-Qdr" id="fjQ-Mz-iad"/>
                         <outlet property="ticketTitle" destination="83h-u0-wFT" id="LFG-F8-WNQ"/>
                     </connections>
@@ -207,6 +303,7 @@
         </scene>
     </scenes>
     <resources>
+        <image name="plus.app" catalog="system" width="128" height="114"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Sluggo/View Controllers/TicketDetailTableViewController.swift
+++ b/Sluggo/View Controllers/TicketDetailTableViewController.swift
@@ -15,6 +15,7 @@ class TicketDetailTableViewController: UITableViewController {
     @IBOutlet var assignedField: UITextField!
     @IBOutlet var statusField: UITextField!
     @IBOutlet var dueDatePicker: UIDatePicker!
+    @IBOutlet weak var tagLabel: UILabel!
     @IBOutlet var dueDateSwitch: UISwitch!
     @IBOutlet var dueDateLabel: UILabel!
     @IBOutlet var navBar: UINavigationItem!
@@ -31,6 +32,7 @@ class TicketDetailTableViewController: UITableViewController {
     var statuses: [StatusRecord?] = [nil]
     var currentMember: MemberRecord?
     var currentStatus: StatusRecord?
+    var selectedTags: [TagRecord?] = [nil]
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -57,6 +59,19 @@ class TicketDetailTableViewController: UITableViewController {
             })
         }
 
+//        let tagManager = TagManager(identity: self.identity)
+//        tagManager.listFromTeams(page: 1) {result in
+//            self.processResult(result: result, onSuccess: { record in
+//                for tag in record.results {
+//                    self.selectedTags.append(tag)
+//                }
+//            })
+//        }
+
+        self.selectedTags = ticket!.tag_list
+
+        refreshTagLabel()
+
         pickerView.dataSource = self
         pickerView.delegate = self
 
@@ -67,6 +82,37 @@ class TicketDetailTableViewController: UITableViewController {
         statusPicker.tag = 2
         updateUI()
 
+    }
+
+    func launchTagPopup() {
+        // launch the view controller holding the tag view
+        if let view = storyboard?.instantiateViewController(identifier: "TagNavigationController") {
+            if let child = view.children[0] as? TicketTabTableViewController {
+                child.identity = self.identity
+                child.selectedTags = self.selectedTags
+                child.completion = { newTags in
+                    self.selectedTags = newTags
+                    self.refreshTagLabel()
+                }
+            }
+            self.present(view, animated: true, completion: nil)
+        }
+    }
+
+    @IBAction func addTagButtonHit(_ sender: Any) {
+        launchTagPopup()
+    }
+
+    func refreshTagLabel() {
+        if selectedTags.count == 0 {
+            tagLabel.text = "No Tags Selected"
+        } else if selectedTags.count == 1 {
+            tagLabel.text = selectedTags[0]?.title
+        } else if selectedTags.count == 2 {
+            tagLabel.text = selectedTags[0]!.title + ", " + selectedTags[1]!.title
+        } else {
+            tagLabel.text = selectedTags[0]!.title + ", " + selectedTags[1]!.title + ", ..."
+        }
     }
 
     func updateUI() {
@@ -223,8 +269,10 @@ extension TicketDetailTableViewController: UIPickerViewDelegate, UIPickerViewDat
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         if pickerView.tag == 1 {
             currentMember = teamMembers[row]
+            // assignedField.text = currentMember?.owner.username ?? "No Assigned User"
         } else {
             currentStatus = statuses[row]
+            // statusField.text = currentStatus?.title ?? "No Status Selected"
         }
     }
 

--- a/Sluggo/View Controllers/TicketDetailTableViewController.swift
+++ b/Sluggo/View Controllers/TicketDetailTableViewController.swift
@@ -111,8 +111,7 @@ class TicketDetailTableViewController: UITableViewController {
         assignedField.isEnabled = true
         navBar.title = self.ticket != nil ? "Selected Ticket" : "Create a Ticket"
         rightButton.title = (self.ticket != nil) ? "Edit" : "Done"
-        
-        
+
         setEditMode(self.ticket == nil)
         createUserPicker()
         createStatusPicker()
@@ -142,7 +141,7 @@ class TicketDetailTableViewController: UITableViewController {
         let member = currentMember?.id
         let status = currentStatus?.id
         let tags = selectedTags.map({$0.id})
-        
+
         let manager = TicketManager(identity)
 
         if editingTicket {

--- a/Sluggo/View Controllers/TicketTabTableViewController.swift
+++ b/Sluggo/View Controllers/TicketTabTableViewController.swift
@@ -27,7 +27,11 @@ class TicketTabTableViewController: UITableViewController {
                 self.completion?(self.selectedTags)
             }
         }
+        let cancelAction = UIAction { _ in
+            self.dismiss(animated: true)
+        }
         navigationItem.rightBarButtonItem = UIBarButtonItem(systemItem: .done, primaryAction: doneAction)
+        navigationItem.leftBarButtonItem = UIBarButtonItem(systemItem: .cancel, primaryAction: cancelAction)
     }
 
     func loadData() {
@@ -37,6 +41,7 @@ class TicketTabTableViewController: UITableViewController {
                 self.processResult(result: result, onSuccess: { record in
                     self.ticketTags = []
                     self.ticketTags += record.results
+                    print(self.ticketTags)
                     self.tableView.reloadData()
                     self.preselectItems()
                 })
@@ -67,14 +72,16 @@ class TicketTabTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
-        var count = 0
-        for selected in selectedTags {
+        for (count, selected) in selectedTags.enumerated() {
             if selected.object_uuid == ticketTags[indexPath.row].object_uuid {
                 selectedTags.remove(at: count)
                 break
             }
-            count+=1
         }
+    }
+
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return "Tags"
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/Sluggo/View Controllers/TicketTabTableViewController.swift
+++ b/Sluggo/View Controllers/TicketTabTableViewController.swift
@@ -44,15 +44,12 @@ class TicketTabTableViewController: UITableViewController {
     }
 
     func preselectItems() {
-        for select in selectedTags {
-            var count = 0
-            for comparison in ticketTags {
-                if select.object_uuid == comparison.object_uuid {
-                    let indexPath = IndexPath(row: count, section: 0)
-                    tableView.selectRow(at: indexPath, animated: true, scrollPosition: .bottom)
-                    break
-                }
-                count += 1
+        let objects = Set(selectedTags.map {$0.object_uuid})
+
+        for (count, comparison) in ticketTags.enumerated() {
+            if objects.contains(comparison.object_uuid) {
+                let indexPath = IndexPath(row: count, section: 0)
+                tableView.selectRow(at: indexPath, animated: true, scrollPosition: .bottom)
             }
         }
     }

--- a/Sluggo/View Controllers/TicketTabTableViewController.swift
+++ b/Sluggo/View Controllers/TicketTabTableViewController.swift
@@ -10,10 +10,10 @@ import UIKit
 class TicketTabTableViewController: UITableViewController {
 
     var identity: AppIdentity!
-    var completion: (([TagRecord?]) -> Void)?
-    var selectedTags: [TagRecord?] = [nil]
+    var completion: (([TagRecord]) -> Void)?
+    var selectedTags: [TagRecord] = []
 
-    var ticketTags: [TagRecord?] = []
+    var ticketTags: [TagRecord] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -41,16 +41,26 @@ class TicketTabTableViewController: UITableViewController {
                         print(tag)
                     }
                     self.tableView.reloadData()
+                    self.preselectItems()
                 })
             }
     }
 
     func preselectItems() {
-
+        for select in selectedTags {
+            var count = 0
+            for comparison in ticketTags {
+                if select.object_uuid == comparison.object_uuid {
+                    let indexPath = IndexPath(row: count, section: 0)
+                    tableView.selectRow(at: indexPath, animated: true, scrollPosition: .bottom)
+                    break
+                }
+                count+=1
+            }
+        }
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        print("I am here. The count is: ")
         print(ticketTags.count)
         return ticketTags.count
     }
@@ -59,8 +69,23 @@ class TicketTabTableViewController: UITableViewController {
                                 indexPath: IndexPath) -> UITableViewCell {
 
         let cell = tableView.dequeueReusableCell(withIdentifier: "TagEntry", for: indexPath)
-        let text = ticketTags[indexPath.row]!.getTitle()
+        let text = ticketTags[indexPath.row].getTitle()
         cell.textLabel?.text = text
         return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+        var count = 0
+        for selected in selectedTags {
+            if selected.object_uuid == ticketTags[indexPath.row].object_uuid {
+                selectedTags.remove(at: count)
+                break
+            }
+            count+=1
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        selectedTags.append(ticketTags[indexPath.row])
     }
 }

--- a/Sluggo/View Controllers/TicketTabTableViewController.swift
+++ b/Sluggo/View Controllers/TicketTabTableViewController.swift
@@ -1,0 +1,66 @@
+//
+//  TicketTabTableViewController.swift
+//  Sluggo
+//
+//  Created by Stephan Martin on 5/16/21.
+//
+
+import UIKit
+
+class TicketTabTableViewController: UITableViewController {
+
+    var identity: AppIdentity!
+    var completion: (([TagRecord?]) -> Void)?
+    var selectedTags: [TagRecord?] = [nil]
+
+    var ticketTags: [TagRecord?] = []
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureBarItems()
+        loadData()
+    }
+
+    func configureBarItems() {
+        let doneAction = UIAction {_ in
+            self.dismiss(animated: true) {
+                self.completion?(self.selectedTags)
+            }
+        }
+        navigationItem.rightBarButtonItem = UIBarButtonItem(systemItem: .done, primaryAction: doneAction)
+    }
+
+    func loadData() {
+
+        let tagManager = TagManager(identity: self.identity)
+            tagManager.listFromTeams(page: 1) {result in
+                self.processResult(result: result, onSuccess: { record in
+                    self.ticketTags = []
+                    for tag in record.results {
+                        self.ticketTags.append(tag)
+                        print(tag)
+                    }
+                    self.tableView.reloadData()
+                })
+            }
+    }
+
+    func preselectItems() {
+
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        print("I am here. The count is: ")
+        print(ticketTags.count)
+        return ticketTags.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt
+                                indexPath: IndexPath) -> UITableViewCell {
+
+        let cell = tableView.dequeueReusableCell(withIdentifier: "TagEntry", for: indexPath)
+        let text = ticketTags[indexPath.row]!.getTitle()
+        cell.textLabel?.text = text
+        return cell
+    }
+}

--- a/Sluggo/View Controllers/TicketTabTableViewController.swift
+++ b/Sluggo/View Controllers/TicketTabTableViewController.swift
@@ -22,7 +22,7 @@ class TicketTabTableViewController: UITableViewController {
     }
 
     func configureBarItems() {
-        let doneAction = UIAction {_ in
+        let doneAction = UIAction { _ in
             self.dismiss(animated: true) {
                 self.completion?(self.selectedTags)
             }
@@ -36,10 +36,7 @@ class TicketTabTableViewController: UITableViewController {
             tagManager.listFromTeams(page: 1) {result in
                 self.processResult(result: result, onSuccess: { record in
                     self.ticketTags = []
-                    for tag in record.results {
-                        self.ticketTags.append(tag)
-                        print(tag)
-                    }
+                    self.ticketTags += record.results
                     self.tableView.reloadData()
                     self.preselectItems()
                 })
@@ -55,13 +52,12 @@ class TicketTabTableViewController: UITableViewController {
                     tableView.selectRow(at: indexPath, animated: true, scrollPosition: .bottom)
                     break
                 }
-                count+=1
+                count += 1
             }
         }
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        print(ticketTags.count)
         return ticketTags.count
     }
 
@@ -69,8 +65,7 @@ class TicketTabTableViewController: UITableViewController {
                                 indexPath: IndexPath) -> UITableViewCell {
 
         let cell = tableView.dequeueReusableCell(withIdentifier: "TagEntry", for: indexPath)
-        let text = ticketTags[indexPath.row].getTitle()
-        cell.textLabel?.text = text
+        cell.textLabel?.text = ticketTags[indexPath.row].getTitle()
         return cell
     }
 


### PR DESCRIPTION
- Ticket's display now contains a tag cell which displays selected tags.
- Tickets can now be created with tags through the app, along with be edited to add or remove tags.
When tags are added, there is a separate modal view that is brought up with a TableView where tags are selected, and then the ticket display is modified when the done button is clicked in this TableView.

Bug Fix
- Fixed bug where ticket status would be reset if you went into ticket edit mode but did not touch the ticket status.