### PR TITLE
Added logout and prevent user from switching teams in nested contexts

### DIFF
--- a/Sluggo.xcodeproj/project.pbxproj
+++ b/Sluggo.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		7DC2A227262948800002CEE6 /* SluggoSidebarContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC2A226262948800002CEE6 /* SluggoSidebarContainerViewController.swift */; };
 		7DC54AE526437AB3000C8300 /* PinnedTicketRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC54AE426437AB3000C8300 /* PinnedTicketRecord.swift */; };
 		7DEA17852639E7B5004E5A71 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7DEA17842639E7B5004E5A71 /* LaunchScreen.storyboard */; };
+		7DF6CBA5265F8D620013CAEA /* UIWindowExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF6CBA4265F8D620013CAEA /* UIWindowExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -166,6 +167,7 @@
 		7DC2A226262948800002CEE6 /* SluggoSidebarContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SluggoSidebarContainerViewController.swift; sourceTree = "<group>"; };
 		7DC54AE426437AB3000C8300 /* PinnedTicketRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedTicketRecord.swift; sourceTree = "<group>"; };
 		7DEA17842639E7B5004E5A71 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		7DF6CBA4265F8D620013CAEA /* UIWindowExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIWindowExtensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -284,6 +286,7 @@
 			isa = PBXGroup;
 			children = (
 				7D778C05264A374C00D4061A /* ViewControllerExtensions.swift */,
+				7DF6CBA4265F8D620013CAEA /* UIWindowExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -575,6 +578,7 @@
 				052258702636100B00B49CE4 /* LaunchViewController.swift in Sources */,
 				3A150A6726365A9A0052934B /* StatusRecord.swift in Sources */,
 				3A90FBB12651CEED00BE4F5D /* TicketTagTableViewCell.swift in Sources */,
+				7DF6CBA5265F8D620013CAEA /* UIWindowExtensions.swift in Sources */,
 				5A25CFF1264BE28100852035 /* HasTitle.swift in Sources */,
 				7D01B55E264FADC40009FA97 /* AdminTableViewController.swift in Sources */,
 				7D53BE6926433D6600400D0E /* PinnedTicketManager.swift in Sources */,

--- a/Sluggo.xcodeproj/project.pbxproj
+++ b/Sluggo.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		7DC54AE526437AB3000C8300 /* PinnedTicketRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC54AE426437AB3000C8300 /* PinnedTicketRecord.swift */; };
 		7DEA17852639E7B5004E5A71 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7DEA17842639E7B5004E5A71 /* LaunchScreen.storyboard */; };
 		7DF6CBA5265F8D620013CAEA /* UIWindowExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF6CBA4265F8D620013CAEA /* UIWindowExtensions.swift */; };
+		7DF6CBA7265F93A90013CAEA /* TitleScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7DF6CBA6265F93A90013CAEA /* TitleScreen.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -168,6 +169,7 @@
 		7DC54AE426437AB3000C8300 /* PinnedTicketRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinnedTicketRecord.swift; sourceTree = "<group>"; };
 		7DEA17842639E7B5004E5A71 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		7DF6CBA4265F8D620013CAEA /* UIWindowExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIWindowExtensions.swift; sourceTree = "<group>"; };
+		7DF6CBA6265F93A90013CAEA /* TitleScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TitleScreen.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -354,6 +356,7 @@
 			children = (
 				7D679F802650EF83000429E8 /* Admin */,
 				5A79FFE0262E562A00D04320 /* Main.storyboard */,
+				7DF6CBA6265F93A90013CAEA /* TitleScreen.storyboard */,
 				7D9963AB261EF3A4002338E7 /* Root.storyboard */,
 				7DC2A21626293F360002CEE6 /* Home.storyboard */,
 				7DC2A21B262943A70002CEE6 /* Sidebar.storyboard */,
@@ -502,6 +505,7 @@
 				5A79FFE1262E562A00D04320 /* Main.storyboard in Resources */,
 				05588A12264DB61E000D8674 /* TeamMembers.storyboard in Resources */,
 				7D9963AD261EF3A4002338E7 /* Root.storyboard in Resources */,
+				7DF6CBA7265F93A90013CAEA /* TitleScreen.storyboard in Resources */,
 				7DEA17852639E7B5004E5A71 /* LaunchScreen.storyboard in Resources */,
 				7D01B55C264FAAEE0009FA97 /* Admin.storyboard in Resources */,
 				3A150A77263CB5F70052934B /* TicketDetail.storyboard in Resources */,

--- a/Sluggo.xcodeproj/project.pbxproj
+++ b/Sluggo.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		7DEA17852639E7B5004E5A71 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7DEA17842639E7B5004E5A71 /* LaunchScreen.storyboard */; };
 		7DF6CBA5265F8D620013CAEA /* UIWindowExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF6CBA4265F8D620013CAEA /* UIWindowExtensions.swift */; };
 		7DF6CBA7265F93A90013CAEA /* TitleScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7DF6CBA6265F93A90013CAEA /* TitleScreen.storyboard */; };
+		7DF6CBA9265F9A8E0013CAEA /* SluggoNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF6CBA8265F9A8E0013CAEA /* SluggoNavigationController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -170,6 +171,7 @@
 		7DEA17842639E7B5004E5A71 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		7DF6CBA4265F8D620013CAEA /* UIWindowExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIWindowExtensions.swift; sourceTree = "<group>"; };
 		7DF6CBA6265F93A90013CAEA /* TitleScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TitleScreen.storyboard; sourceTree = "<group>"; };
+		7DF6CBA8265F9A8E0013CAEA /* SluggoNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SluggoNavigationController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -386,6 +388,7 @@
 				05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */,
 				7D01B55D264FADC40009FA97 /* AdminTableViewController.swift */,
 				3A90FBB426531AC600BE4F5D /* AdminUserRolesTableViewController.swift */,
+				7DF6CBA8265F9A8E0013CAEA /* SluggoNavigationController.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -574,6 +577,7 @@
 				2FF89024264BBAC600D50B69 /* TicketDetailTableViewController.swift in Sources */,
 				5AC6459026412F0C00F46137 /* TeamTableViewCell.swift in Sources */,
 				051AAB0B2630FD6500BCB9C7 /* Constants.swift in Sources */,
+				7DF6CBA9265F9A8E0013CAEA /* SluggoNavigationController.swift in Sources */,
 				2F3F66E2262DD3BA0040404C /* JsonLoader.swift in Sources */,
 				2F2247AC262920AC006C6EE6 /* TokenRecord.swift in Sources */,
 				7D1DA6AE262B82C200E7C12D /* RootViewController.swift in Sources */,

--- a/Sluggo/AppDelegate.swift
+++ b/Sluggo/AppDelegate.swift
@@ -31,6 +31,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         })
         window!.rootViewController = initialViewController
         window!.makeKeyAndVisible()
+        
+        // If any windows exist below, delete them
+        if(!(UIApplication.shared.windows.first == window)) {
+            UIApplication.shared.windows[0].dismiss()
+        }
     }
 
     // MARK: UISceneSession Lifecycle

--- a/Sluggo/AppDelegate.swift
+++ b/Sluggo/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     // https://stackoverflow.com/questions/33714671/value-of-type-appdelegate-has-no-member-window
-    private func configureInitialViewController() {
+    func configureInitialViewController() {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
         let initialViewController: UIViewController
 

--- a/Sluggo/Storyboards/Home.storyboard
+++ b/Sluggo/Storyboards/Home.storyboard
@@ -10,7 +10,7 @@
         <!--Home-->
         <scene sceneID="fCq-cQ-Aax">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="m5Q-5j-Nv9" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="m5Q-5j-Nv9" customClass="SluggoNavigationController" customModule="Sluggo" customModuleProvider="target" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Home" image="house" catalog="system" id="eDv-6q-5wM"/>
                     <toolbarItems/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
@@ -62,29 +62,29 @@
                                 <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableViewCell>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="TicketCell" id="QBi-YU-uEd" customClass="TicketTableViewCell" customModule="Sluggo" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="93" width="414" height="100"/>
+                                <rect key="frame" x="0.0" y="93" width="414" height="100.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="QBi-YU-uEd" id="TR4-pR-d2i">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="100.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WcM-P6-WUn" customClass="TicketTableViewCell" customModule="Sluggo" customModuleProvider="target">
-                                            <rect key="frame" x="7" y="5" width="400" height="90"/>
+                                            <rect key="frame" x="7" y="5" width="400" height="90.5"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="R8Z-r2-eLl">
-                                                    <rect key="frame" x="14" y="27" width="307" height="21"/>
+                                                    <rect key="frame" x="14" y="27" width="307" height="21.5"/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A58-Co-aDx">
-                                                    <rect key="frame" x="14" y="43" width="307" height="21"/>
+                                                    <rect key="frame" x="14" y="43" width="307" height="21.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" systemColor="systemGray5Color"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="sKv-hG-Y7C">
-                                                    <rect key="frame" x="379" y="37" width="12.5" height="16.5"/>
+                                                    <rect key="frame" x="379" y="37.5" width="12.5" height="16.5"/>
                                                     <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </imageView>
                                             </subviews>

--- a/Sluggo/Storyboards/Sidebar.storyboard
+++ b/Sluggo/Storyboards/Sidebar.storyboard
@@ -40,7 +40,13 @@
                             <outlet property="delegate" destination="PJK-Xs-1jr" id="hoY-C6-eCq"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Teams" largeTitleDisplayMode="always" id="s2u-Yn-B73"/>
+                    <navigationItem key="navigationItem" title="Teams" largeTitleDisplayMode="always" id="s2u-Yn-B73">
+                        <barButtonItem key="leftBarButtonItem" title="Log Out" id="AWX-g9-4q7">
+                            <connections>
+                                <action selector="doLogOutAction:" destination="PJK-Xs-1jr" id="ees-yu-euF"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HKS-Hy-anX" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Sluggo/Storyboards/TeamMembers.storyboard
+++ b/Sluggo/Storyboards/TeamMembers.storyboard
@@ -55,7 +55,7 @@
         <!--Members-->
         <scene sceneID="ami-Zl-Jrs">
             <objects>
-                <navigationController id="E8f-aG-d2W" sceneMemberID="viewController">
+                <navigationController id="E8f-aG-d2W" customClass="SluggoNavigationController" customModule="Sluggo" customModuleProvider="target" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Members" image="person.2.fill" catalog="system" id="urg-qZ-4T3"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="1QG-Aw-Qpg">

--- a/Sluggo/Storyboards/Ticket.storyboard
+++ b/Sluggo/Storyboards/Ticket.storyboard
@@ -130,7 +130,7 @@
         <!--Tickets-->
         <scene sceneID="Shx-pT-pdo">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Uq0-p5-H1Z" sceneMemberID="viewController">
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Uq0-p5-H1Z" customClass="SluggoNavigationController" customModule="Sluggo" customModuleProvider="target" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Tickets" image="ticket" catalog="system" id="bbG-bf-pLB"/>
                     <toolbarItems/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>

--- a/Sluggo/Storyboards/TitleScreen.storyboard
+++ b/Sluggo/Storyboards/TitleScreen.storyboard
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ZlY-un-hqu">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="qQM-Mc-JA4">
+            <objects>
+                <viewController storyboardIdentifier="launchView" id="ZlY-un-hqu" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="1Jb-W6-yCh">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sluggo iOS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2fJ-j2-tOj">
+                                <rect key="frame" x="164.5" y="437.5" width="85" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="i3x-ua-NgZ"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="2fJ-j2-tOj" firstAttribute="centerX" secondItem="1Jb-W6-yCh" secondAttribute="centerX" id="2ab-x5-4HP"/>
+                            <constraint firstItem="2fJ-j2-tOj" firstAttribute="centerY" secondItem="1Jb-W6-yCh" secondAttribute="centerY" id="QGt-FX-vzD"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ek0-VW-hII" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2880" y="92"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Sluggo/View Controllers/Extensions/UIWindowExtensions.swift
+++ b/Sluggo/View Controllers/Extensions/UIWindowExtensions.swift
@@ -1,0 +1,17 @@
+//
+//  UIWindowExtensions.swift
+//  Sluggo
+//
+//  Created by Isaac Trimble-Pederson on 5/27/21.
+//
+
+import UIKit
+
+// Obtained from Stack Overflow here https://stackoverflow.com/questions/4544489/how-to-remove-a-uiwindow
+// Not accounting for pre-iOS 12 because we are targeting latest
+extension UIWindow {
+    func dismiss() {
+        isHidden = true
+        windowScene = nil
+    }
+}

--- a/Sluggo/View Controllers/RootViewController.swift
+++ b/Sluggo/View Controllers/RootViewController.swift
@@ -62,23 +62,24 @@ class RootViewController: UIViewController {
 
     func logOutAction() {
         // This needs to be done in a specific order to avoid nil exceptions
-
         // First, dismiss the main view controller and sidebar
-        // Assume we are in the key window
-        let keyWindow = UIApplication.shared.keyWindow
-        keyWindow?.dismiss()
+        self.mainTabBarController?.dismiss(animated: true, completion: {
+            // Assume we are in the key window
+            let keyWindow = UIApplication.shared.keyWindow
+            keyWindow?.dismiss()
 
-        // Hopefully the user cannot access anything now
-        // We don't do background calls to API so this *shouldn't* crash
-        // Remove AppIdentity persistence file
-        let identityClearingSuccess = AppIdentity.deletePersistenceFile()
+            // Hopefully the user cannot access anything now
+            // We don't do background calls to API so this *shouldn't* crash
+            // Remove AppIdentity persistence file
+            let identityClearingSuccess = AppIdentity.deletePersistenceFile()
 
-        // After this is done, make a call to reconfigure
-        guard let application = UIApplication.shared.delegate as? AppDelegate else {
-            print("FUCK")
-            return
-        }
-        application.configureInitialViewController()
+            // After this is done, make a call to reconfigure
+            guard let application = UIApplication.shared.delegate as? AppDelegate else {
+                print("FUCK")
+                return
+            }
+            application.configureInitialViewController()
+        })
     }
 
     func getMember(completionHandler: @escaping ((MemberRecord) -> Void)) {

--- a/Sluggo/View Controllers/RootViewController.swift
+++ b/Sluggo/View Controllers/RootViewController.swift
@@ -66,16 +66,28 @@ class RootViewController: UIViewController {
         self.mainTabBarController?.dismiss(animated: true, completion: {
             // Assume we are in the key window
             let keyWindow = UIApplication.shared.keyWindow
+
+            // Setup temporary window to make it look like we don't cut in and out
+            // Relies on logo VC being identical in nature to existing VC
+            let temporaryLogoWindow = UIWindow()
+            let logoStoryboard = UIStoryboard(name: "TitleScreen", bundle: Bundle.main)
+            let logoVC = logoStoryboard.instantiateInitialViewController()
+            temporaryLogoWindow.rootViewController = logoVC
+
+            // Make new logo window visible
+            temporaryLogoWindow.makeKeyAndVisible()
+
+            // Dismiss our old window after this has been made key and visible
             keyWindow?.dismiss()
 
             // Hopefully the user cannot access anything now
             // We don't do background calls to API so this *shouldn't* crash
             // Remove AppIdentity persistence file
-            let identityClearingSuccess = AppIdentity.deletePersistenceFile()
+            _ = AppIdentity.deletePersistenceFile()
 
             // After this is done, make a call to reconfigure
+            // Reconfiguring will remove the logo window if it exists
             guard let application = UIApplication.shared.delegate as? AppDelegate else {
-                print("FUCK")
                 return
             }
             application.configureInitialViewController()

--- a/Sluggo/View Controllers/RootViewController.swift
+++ b/Sluggo/View Controllers/RootViewController.swift
@@ -118,7 +118,7 @@ class RootViewController: UIViewController {
                     adminVC.identity = self.identity // Does this create a race condition?
 
                     // Wrap this in a navigation controller
-                    let navVC = UINavigationController(rootViewController: adminVC)
+                    let navVC = SluggoNavigationController(rootViewController: adminVC)
 
                     // Create bar button item
                     let adminBarButtonImage = UIImage(systemName: "shield")
@@ -197,7 +197,7 @@ class RootViewController: UIViewController {
         /*
          * Some notes on the below implementation:
          * We determine if we can present based on the number of VCs in the
-         * navigation stack of each controller. This is acceptable, because
+         * navigation stack of the selected tab controller. This is acceptable, because
          * navigation presentation is susceptible to still recieving the
          * sidebar gestures.
          *
@@ -207,23 +207,14 @@ class RootViewController: UIViewController {
         guard let tabBarControllerVCs = mainTabBarController?.viewControllers
         else { return false } // return false if something goes wrong in determining
 
-        var shouldPresentSidebar = true
-
-        for tabVC in tabBarControllerVCs {
-            if let navVC = tabVC as? UINavigationController {
-                if navVC.viewControllers.count > 1 {
-                    // More than one view controller present
-                    print(navVC.viewControllers)
-                    shouldPresentSidebar = false
-                    break // save additional cycles
-                }
-            } else {
-                print("RootViewController: Error: Root view controller on" +
-                      " tab bar controller was not a navigation controller")
-                continue
+        let selectedTabVC = self.mainTabBarController?.selectedViewController
+        if let navVC = selectedTabVC as? UINavigationController {
+            if navVC.viewControllers.count > 1 {
+                // More than one view controller present
+                return false
             }
         }
 
-        return shouldPresentSidebar
+        return true
     }
 }

--- a/Sluggo/View Controllers/SluggoNavigationController.swift
+++ b/Sluggo/View Controllers/SluggoNavigationController.swift
@@ -1,0 +1,35 @@
+//
+//  SluggoNavigationController.swift
+//  Sluggo
+//
+//  Created by Isaac Trimble-Pederson on 5/27/21.
+//
+
+import UIKit
+
+/**
+ This class is identical to the Navigation Controller, but enables listening for the team
+ changer notification, upon which it will unwind to the root. This prevents potential
+ inconsistencies with nested presenting controllers, and enables the user to switch
+ from them when something is being presented in another controller.
+ 
+ Note: This only handles the case with regards to navigation presentation, but this is
+ OK as modal presentations will block the tab bar.
+ */
+class SluggoNavigationController: UINavigationController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(didRecieveTeamChange),
+                                               name: Constants.Signals.TEAM_CHANGE_NOTIFICATION,
+                                               object: nil)
+    }
+
+    @objc private func didRecieveTeamChange() {
+        self.popToRootViewController(animated: true)
+    }
+
+}

--- a/Sluggo/View Controllers/SluggoSidebarContainerViewController.swift
+++ b/Sluggo/View Controllers/SluggoSidebarContainerViewController.swift
@@ -15,6 +15,7 @@ class SluggoSidebarContainerViewController: UIViewController {
     @IBOutlet weak var sidebarContainerLeadingConstraint: NSLayoutConstraint!
 
     private var identity: AppIdentity
+    var logOutAction: (() -> Void)?
 
     init? (coder: NSCoder, identity: AppIdentity) {
         self.identity = identity
@@ -100,6 +101,7 @@ class SluggoSidebarContainerViewController: UIViewController {
     @IBSegueAction func launchSidebar(_ coder: NSCoder) -> UITableViewController? {
         let view = TeamTableViewController(coder: coder)
         view?.identity = self.identity
+        view?.logOutAction = self.logOutAction
         view?.completion = { team in
             self.identity.team = team
             NotificationCenter.default.post(name: Constants.Signals.TEAM_CHANGE_NOTIFICATION, object: nil)

--- a/Sluggo/View Controllers/TeamTableViewController.swift
+++ b/Sluggo/View Controllers/TeamTableViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 class TeamTableViewController: UITableViewController {
     var identity: AppIdentity!
     var completion: ((TeamRecord) -> Void)?
+    var logOutAction: (() -> Void)?
     private var maxNumber: Int = 0
     private var fetchingTeams: [TeamRecord] = []
     private var teams: [TeamRecord] = []
@@ -82,4 +83,9 @@ class TeamTableViewController: UITableViewController {
                              after: after)
         }
     }
+    
+    @IBAction func doLogOutAction(_ sender: Any) {
+        self.logOutAction?()
+    }
+    
 }


### PR DESCRIPTION
This adds logout and prevention for activating the sidebar when presentations are nested.

I chose to approach implementing logout by effectively resetting the app; it will re-run the configuration method from the delegate. A stand-in window that matches the appearance is added to mask any kind of animation defects from this approach. This simplifies our configuration, since we will get a clean identity passed in, lowering the chances of race conditions which would occur if we nullified the AppIdentity. This simplifies the code overall (even though it's kind of an ugly hack)

Sidebar prevention enables the root view controller to inspect the navigation controllers of the selected tab. If the navigation controller has more than one VC on its stack, sidebar navigation will be disabled. I also added a custom navigation controller which adds a notification to unwind to the root when the team is changed. All tabs should make use of this custom controller (and I have migrated to it in the code)