### PR TITLE
Fixed bug when members don't get refreshed on team change

### DIFF
--- a/Sluggo/View Controllers/HomeTableViewController.swift
+++ b/Sluggo/View Controllers/HomeTableViewController.swift
@@ -41,6 +41,7 @@ class HomeTableViewController: UITableViewController {
                                                object: nil,
                                                queue: nil) { _ in
             self.refreshContent()
+            NotificationCenter.default.post(name: .refreshMembers, object: self)
         }
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(refreshContent),


### PR DESCRIPTION
- As title states, fixed bug when members don't get refreshed when you change from one team to another, causing one team to display another team's members until a refresh is called manually.