### PR TITLE
Tebert/pending invites

### DIFF
--- a/Sluggo.xcodeproj/project.pbxproj
+++ b/Sluggo.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		052258702636100B00B49CE4 /* LaunchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0522586F2636100B00B49CE4 /* LaunchViewController.swift */; };
 		053A259F26645DDD0072A773 /* PendingInvitesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053A259E26645DDD0072A773 /* PendingInvitesViewController.swift */; };
 		0541572326655FBA002A85F2 /* InviteManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0541572226655FBA002A85F2 /* InviteManager.swift */; };
+		0541572826659F2E002A85F2 /* InviteRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0541572726659F2E002A85F2 /* InviteRecord.swift */; };
 		05588A12264DB61E000D8674 /* TeamMembers.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 05588A11264DB61E000D8674 /* TeamMembers.storyboard */; };
 		05DE0CD7264F11E400D69C61 /* MemberListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */; };
 		2F2247AC262920AC006C6EE6 /* TokenRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2247AB262920AC006C6EE6 /* TokenRecord.swift */; };
@@ -105,6 +106,7 @@
 		0522586F2636100B00B49CE4 /* LaunchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewController.swift; sourceTree = "<group>"; };
 		053A259E26645DDD0072A773 /* PendingInvitesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingInvitesViewController.swift; sourceTree = "<group>"; };
 		0541572226655FBA002A85F2 /* InviteManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteManager.swift; sourceTree = "<group>"; };
+		0541572726659F2E002A85F2 /* InviteRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteRecord.swift; sourceTree = "<group>"; };
 		05588A11264DB61E000D8674 /* TeamMembers.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TeamMembers.storyboard; sourceTree = "<group>"; };
 		05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemberListViewController.swift; sourceTree = "<group>"; };
 		2F2247AB262920AC006C6EE6 /* TokenRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRecord.swift; sourceTree = "<group>"; };
@@ -268,6 +270,7 @@
 				3A150A6626365A9A0052934B /* StatusRecord.swift */,
 				3A150A6B26365B670052934B /* TagRecord.swift */,
 				7DC54AE426437AB3000C8300 /* PinnedTicketRecord.swift */,
+				0541572726659F2E002A85F2 /* InviteRecord.swift */,
 			);
 			path = Codables;
 			sourceTree = "<group>";
@@ -577,6 +580,7 @@
 				5AB1C8FC262FF1690010F85E /* TicketRecord.swift in Sources */,
 				3A90FBB32651D76900BE4F5D /* TicketTabTableViewController.swift in Sources */,
 				5A25CFDF264BCF2C00852035 /* TicketFilterParameters.swift in Sources */,
+				0541572826659F2E002A85F2 /* InviteRecord.swift in Sources */,
 				5A25CFE7264BD73D00852035 /* TicketFilterTableViewCell.swift in Sources */,
 				7D1DA6B7262B866D00E7C12D /* SidebarData.swift in Sources */,
 				3A90FBB526531AC600BE4F5D /* AdminUserRolesTableViewController.swift in Sources */,

--- a/Sluggo.xcodeproj/project.pbxproj
+++ b/Sluggo.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		053A259F26645DDD0072A773 /* PendingInvitesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053A259E26645DDD0072A773 /* PendingInvitesViewController.swift */; };
 		0541572326655FBA002A85F2 /* InviteManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0541572226655FBA002A85F2 /* InviteManager.swift */; };
 		0541572826659F2E002A85F2 /* InviteRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0541572726659F2E002A85F2 /* InviteRecord.swift */; };
+		0541572D2665BD29002A85F2 /* AdminInviteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0541572C2665BD29002A85F2 /* AdminInviteViewController.swift */; };
 		05588A12264DB61E000D8674 /* TeamMembers.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 05588A11264DB61E000D8674 /* TeamMembers.storyboard */; };
 		05DE0CD7264F11E400D69C61 /* MemberListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */; };
 		2F2247AC262920AC006C6EE6 /* TokenRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2247AB262920AC006C6EE6 /* TokenRecord.swift */; };
@@ -107,6 +108,7 @@
 		053A259E26645DDD0072A773 /* PendingInvitesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingInvitesViewController.swift; sourceTree = "<group>"; };
 		0541572226655FBA002A85F2 /* InviteManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteManager.swift; sourceTree = "<group>"; };
 		0541572726659F2E002A85F2 /* InviteRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteRecord.swift; sourceTree = "<group>"; };
+		0541572C2665BD29002A85F2 /* AdminInviteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminInviteViewController.swift; sourceTree = "<group>"; };
 		05588A11264DB61E000D8674 /* TeamMembers.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TeamMembers.storyboard; sourceTree = "<group>"; };
 		05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemberListViewController.swift; sourceTree = "<group>"; };
 		2F2247AB262920AC006C6EE6 /* TokenRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRecord.swift; sourceTree = "<group>"; };
@@ -404,6 +406,7 @@
 				3A90FBB426531AC600BE4F5D /* AdminUserRolesTableViewController.swift */,
 				7DF6CBA8265F9A8E0013CAEA /* SluggoNavigationController.swift */,
 				3A90FBBA265F4FAB00BE4F5D /* AdminTagViewController.swift */,
+				0541572C2665BD29002A85F2 /* AdminInviteViewController.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -615,6 +618,7 @@
 				5AB1C8F7262FE3520010F85E /* AppIdentity.swift in Sources */,
 				7D9963A6261EF3A4002338E7 /* AppDelegate.swift in Sources */,
 				5A673570263BF2D200C4C778 /* UIColor.swift in Sources */,
+				0541572D2665BD29002A85F2 /* AdminInviteViewController.swift in Sources */,
 				3A150A6C26365B670052934B /* TagRecord.swift in Sources */,
 				5A25CFB1264B9A9300852035 /* Methods.swift in Sources */,
 				7D778C06264A374C00D4061A /* ViewControllerExtensions.swift in Sources */,

--- a/Sluggo.xcodeproj/project.pbxproj
+++ b/Sluggo.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		051AAB0B2630FD6500BCB9C7 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051AAB0A2630FD6500BCB9C7 /* Constants.swift */; };
 		052258702636100B00B49CE4 /* LaunchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0522586F2636100B00B49CE4 /* LaunchViewController.swift */; };
+		053A259F26645DDD0072A773 /* PendingInvitesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053A259E26645DDD0072A773 /* PendingInvitesViewController.swift */; };
 		05588A12264DB61E000D8674 /* TeamMembers.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 05588A11264DB61E000D8674 /* TeamMembers.storyboard */; };
 		05DE0CD7264F11E400D69C61 /* MemberListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */; };
 		2F2247AC262920AC006C6EE6 /* TokenRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2247AB262920AC006C6EE6 /* TokenRecord.swift */; };
@@ -101,6 +102,7 @@
 /* Begin PBXFileReference section */
 		051AAB0A2630FD6500BCB9C7 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		0522586F2636100B00B49CE4 /* LaunchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewController.swift; sourceTree = "<group>"; };
+		053A259E26645DDD0072A773 /* PendingInvitesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingInvitesViewController.swift; sourceTree = "<group>"; };
 		05588A11264DB61E000D8674 /* TeamMembers.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TeamMembers.storyboard; sourceTree = "<group>"; };
 		05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemberListViewController.swift; sourceTree = "<group>"; };
 		2F2247AB262920AC006C6EE6 /* TokenRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRecord.swift; sourceTree = "<group>"; };
@@ -385,6 +387,7 @@
 				7DC2A226262948800002CEE6 /* SluggoSidebarContainerViewController.swift */,
 				5A9FF88D26386D4700378550 /* TicketListController.swift */,
 				5A9C4C1B2640BC4E00B270AB /* TeamTableViewController.swift */,
+				053A259E26645DDD0072A773 /* PendingInvitesViewController.swift */,
 				5A9C4C202641113D00B270AB /* TeamSelectorContainerViewController.swift */,
 				7D23834A264119050091C7E8 /* HomeTableViewController.swift */,
 				5A25CFAB264B966300852035 /* TicketFilterTableViewController.swift */,
@@ -611,6 +614,7 @@
 				5AB1C8EF262FE3210010F85E /* TagManager.swift in Sources */,
 				5A9FF88E26386D4700378550 /* TicketListController.swift in Sources */,
 				5AB1C8E5262FE2E60010F85E /* TicketManager.swift in Sources */,
+				053A259F26645DDD0072A773 /* PendingInvitesViewController.swift in Sources */,
 				2F3AD7A82627C89B00B61A97 /* MemberRecord.swift in Sources */,
 				5AB1C8DD262FE2DD0010F85E /* TeamManager.swift in Sources */,
 				5A00A045263A34CC0085C8C6 /* TicketTableViewCell.swift in Sources */,

--- a/Sluggo.xcodeproj/project.pbxproj
+++ b/Sluggo.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		051AAB0B2630FD6500BCB9C7 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 051AAB0A2630FD6500BCB9C7 /* Constants.swift */; };
 		052258702636100B00B49CE4 /* LaunchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0522586F2636100B00B49CE4 /* LaunchViewController.swift */; };
 		053A259F26645DDD0072A773 /* PendingInvitesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053A259E26645DDD0072A773 /* PendingInvitesViewController.swift */; };
+		0541572326655FBA002A85F2 /* InviteManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0541572226655FBA002A85F2 /* InviteManager.swift */; };
 		05588A12264DB61E000D8674 /* TeamMembers.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 05588A11264DB61E000D8674 /* TeamMembers.storyboard */; };
 		05DE0CD7264F11E400D69C61 /* MemberListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */; };
 		2F2247AC262920AC006C6EE6 /* TokenRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2247AB262920AC006C6EE6 /* TokenRecord.swift */; };
@@ -103,6 +104,7 @@
 		051AAB0A2630FD6500BCB9C7 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		0522586F2636100B00B49CE4 /* LaunchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewController.swift; sourceTree = "<group>"; };
 		053A259E26645DDD0072A773 /* PendingInvitesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingInvitesViewController.swift; sourceTree = "<group>"; };
+		0541572226655FBA002A85F2 /* InviteManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteManager.swift; sourceTree = "<group>"; };
 		05588A11264DB61E000D8674 /* TeamMembers.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TeamMembers.storyboard; sourceTree = "<group>"; };
 		05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemberListViewController.swift; sourceTree = "<group>"; };
 		2F2247AB262920AC006C6EE6 /* TokenRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRecord.swift; sourceTree = "<group>"; };
@@ -280,6 +282,7 @@
 				5AB1C8EE262FE3210010F85E /* TagManager.swift */,
 				5AB1C908262FFF500010F85E /* UserManager.swift */,
 				5A25CFA6264B934400852035 /* StatusManager.swift */,
+				0541572226655FBA002A85F2 /* InviteManager.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -570,6 +573,7 @@
 			files = (
 				5A9C4C212641113D00B270AB /* TeamSelectorContainerViewController.swift in Sources */,
 				5A79FFE6262E563F00D04320 /* LoginViewController.swift in Sources */,
+				0541572326655FBA002A85F2 /* InviteManager.swift in Sources */,
 				5AB1C8FC262FF1690010F85E /* TicketRecord.swift in Sources */,
 				3A90FBB32651D76900BE4F5D /* TicketTabTableViewController.swift in Sources */,
 				5A25CFDF264BCF2C00852035 /* TicketFilterParameters.swift in Sources */,

--- a/Sluggo.xcodeproj/project.pbxproj
+++ b/Sluggo.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		0541572826659F2E002A85F2 /* InviteRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0541572726659F2E002A85F2 /* InviteRecord.swift */; };
 		0541572D2665BD29002A85F2 /* AdminInviteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0541572C2665BD29002A85F2 /* AdminInviteViewController.swift */; };
 		05588A12264DB61E000D8674 /* TeamMembers.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 05588A11264DB61E000D8674 /* TeamMembers.storyboard */; };
+		05D3BA1A2666B9F8008AE9D8 /* AdminInvite.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 05D3BA192666B9F8008AE9D8 /* AdminInvite.storyboard */; };
+		05D3BA272666DA3D008AE9D8 /* PendingInvites.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 05D3BA262666DA3D008AE9D8 /* PendingInvites.storyboard */; };
 		05DE0CD7264F11E400D69C61 /* MemberListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */; };
 		2F2247AC262920AC006C6EE6 /* TokenRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2247AB262920AC006C6EE6 /* TokenRecord.swift */; };
 		2F3AD7A32627C86A00B61A97 /* UserRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F3AD7A22627C86A00B61A97 /* UserRecord.swift */; };
@@ -110,6 +112,8 @@
 		0541572726659F2E002A85F2 /* InviteRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteRecord.swift; sourceTree = "<group>"; };
 		0541572C2665BD29002A85F2 /* AdminInviteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdminInviteViewController.swift; sourceTree = "<group>"; };
 		05588A11264DB61E000D8674 /* TeamMembers.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TeamMembers.storyboard; sourceTree = "<group>"; };
+		05D3BA192666B9F8008AE9D8 /* AdminInvite.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = AdminInvite.storyboard; sourceTree = "<group>"; };
+		05D3BA262666DA3D008AE9D8 /* PendingInvites.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = PendingInvites.storyboard; sourceTree = "<group>"; };
 		05DE0CD6264F11E400D69C61 /* MemberListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemberListViewController.swift; sourceTree = "<group>"; };
 		2F2247AB262920AC006C6EE6 /* TokenRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRecord.swift; sourceTree = "<group>"; };
 		2F3AD7A22627C86A00B61A97 /* UserRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRecord.swift; sourceTree = "<group>"; };
@@ -297,6 +301,7 @@
 			children = (
 				7D01B55B264FAAEE0009FA97 /* Admin.storyboard */,
 				3A90FBB8265F4E7900BE4F5D /* AdminTag.storyboard */,
+				05D3BA192666B9F8008AE9D8 /* AdminInvite.storyboard */,
 			);
 			path = Admin;
 			sourceTree = "<group>";
@@ -377,6 +382,7 @@
 				7D9963AB261EF3A4002338E7 /* Root.storyboard */,
 				7DC2A21626293F360002CEE6 /* Home.storyboard */,
 				7DC2A21B262943A70002CEE6 /* Sidebar.storyboard */,
+				05D3BA262666DA3D008AE9D8 /* PendingInvites.storyboard */,
 				5A9FF88826386D1400378550 /* Ticket.storyboard */,
 				7DEA17842639E7B5004E5A71 /* LaunchScreen.storyboard */,
 				3A150A76263CB5F70052934B /* TicketDetail.storyboard */,
@@ -531,8 +537,10 @@
 				7DEA17852639E7B5004E5A71 /* LaunchScreen.storyboard in Resources */,
 				7D01B55C264FAAEE0009FA97 /* Admin.storyboard in Resources */,
 				3A150A77263CB5F70052934B /* TicketDetail.storyboard in Resources */,
+				05D3BA1A2666B9F8008AE9D8 /* AdminInvite.storyboard in Resources */,
 				7DC2A21726293F360002CEE6 /* Home.storyboard in Resources */,
 				7DC2A21C262943A70002CEE6 /* Sidebar.storyboard in Resources */,
+				05D3BA272666DA3D008AE9D8 /* PendingInvites.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sluggo/Models/Codables/InviteRecord.swift
+++ b/Sluggo/Models/Codables/InviteRecord.swift
@@ -9,7 +9,13 @@ import Foundation
 import NullCodable
 
 // swiftlint:disable identifier_name
-struct InviteRecord: Codable {
+struct UserInviteRecord: Codable {
     var id: Int
+    var team: TeamRecord
+}
+
+struct TeamInviteRecord: Codable {
+    var id: Int
+    var email: String
     var team: TeamRecord
 }

--- a/Sluggo/Models/Codables/InviteRecord.swift
+++ b/Sluggo/Models/Codables/InviteRecord.swift
@@ -16,6 +16,10 @@ struct UserInviteRecord: Codable {
 
 struct TeamInviteRecord: Codable {
     var id: Int
-    var email: String
+    var user_email: String
     var team: TeamRecord
+}
+
+struct WriteTeamInviteRecord: Codable {
+    var user_email: String
 }

--- a/Sluggo/Models/Codables/InviteRecord.swift
+++ b/Sluggo/Models/Codables/InviteRecord.swift
@@ -1,0 +1,15 @@
+//
+//  InviteRecord.swift
+//  Sluggo
+//
+//  Created by Troy Ebert on 5/31/21.
+//
+
+import Foundation
+import NullCodable
+
+// swiftlint:disable identifier_name
+struct InviteRecord: Codable {
+    var id: Int
+    var team: TeamRecord
+}

--- a/Sluggo/Models/Managers/InviteManager.swift
+++ b/Sluggo/Models/Managers/InviteManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+// MARK: User Invite Manager
 class InviteManager {
 
     static let urlBase = "api/users/invites/"
@@ -16,7 +17,6 @@ class InviteManager {
         self.identity = identity
     }
 
-    // MARK: User Invite Manager
     func getUserInvites(completionHandler: @escaping (Result<[UserInviteRecord], Error>) -> Void) {
 
         let urlString = identity.baseAddress + InviteManager.urlBase
@@ -48,10 +48,20 @@ class InviteManager {
         JsonLoader.executeEmptyRequest(request: requestBuilder.getRequest(), completionHandler: completionHandler)
 
     }
+}
 
-    // MARK: Team Invite Manager
-    func getTeamInvites(page: Int,
-                        completionHandler: @escaping (Result<PaginatedList<TeamInviteRecord>, Error>) -> Void) {
+// MARK: Team Invite Manager
+class TeamInviteManager: TeamPaginatedListable {
+
+    static let urlBase = "api/users/invites/"
+    private var identity: AppIdentity
+
+    init(identity: AppIdentity) {
+        self.identity = identity
+    }
+
+    func listFromTeams(page: Int, completionHandler: @escaping
+                        (Result<PaginatedList<TeamInviteRecord>, Error>) -> Void) {
 
         let urlString = identity.baseAddress + TeamManager.urlBase + "\(identity.team!.id)/" + "invites/"
         let requestBuilder = URLRequestBuilder(url: URL(string: urlString)!)
@@ -61,11 +71,11 @@ class InviteManager {
         JsonLoader.executeCodableRequest(request: requestBuilder.getRequest(), completionHandler: completionHandler)
     }
 
-    func addTeamInvite(user: UserRecord, completionHandler: @escaping(Result<Void, Error>) -> Void) {
+    func addTeamInvite(invite: WriteTeamInviteRecord, completionHandler: @escaping(Result<Void, Error>) -> Void) {
 
         let urlString = identity.baseAddress + TeamManager.urlBase + "\(identity.team!.id)/" + "invites/"
 
-        guard let body = JsonLoader.encode(object: user) else {
+        guard let body = JsonLoader.encode(object: invite) else {
             let errorMessage = "Failed to serialize ticket JSON for addTeamInvite in InviteManager"
             completionHandler(.failure(Exception.runtimeError(message: errorMessage)))
             return
@@ -79,12 +89,13 @@ class InviteManager {
         JsonLoader.executeEmptyRequest(request: requestBuilder.getRequest(), completionHandler: completionHandler)
     }
 
-    func deleteTeamInvite(invite: UserInviteRecord, completionHandler: @escaping(Result<Void, Error>) -> Void) {
+    func deleteTeamInvite(invite: TeamInviteRecord, completionHandler: @escaping(Result<Void, Error>) -> Void) {
 
-        let urlString = identity.baseAddress + TeamManager.urlBase + "\(identity.team!.id)/" + "invites/"
+        let urlString = identity.baseAddress + TeamManager.urlBase +
+            "\(identity.team!.id)/" + "invites/" + "\(invite.id)/"
         let requestBuilder = URLRequestBuilder(url: URL(string: urlString)!)
             .setIdentity(identity: identity)
-            .setMethod(method: .GET)
+            .setMethod(method: .DELETE)
 
         JsonLoader.executeEmptyRequest(request: requestBuilder.getRequest(), completionHandler: completionHandler)
     }

--- a/Sluggo/Models/Managers/InviteManager.swift
+++ b/Sluggo/Models/Managers/InviteManager.swift
@@ -7,19 +7,18 @@
 
 import Foundation
 
-class InviteManager: TeamPaginatedListable {
+class InviteManager {
 
-    static let urlBase = "api/teams/"
+    static let urlBase = "api/users/invites/"
     private var identity: AppIdentity
 
     init(identity: AppIdentity) {
         self.identity = identity
     }
 
-    func listFromTeams(page: Int, completionHandler: @escaping (Result<PaginatedList<TeamRecord>, Error>) -> Void) {
+    func getInvites(completionHandler: @escaping (Result<[InviteRecord], Error>) -> Void) {
 
-        let urlString = identity.baseAddress + TeamManager.urlBase + "\(identity.team!.id)"
-            + "/invites/" + "?page=\(page)"
+        let urlString = identity.baseAddress + InviteManager.urlBase
         let requestBuilder = URLRequestBuilder(url: URL(string: urlString)!)
             .setIdentity(identity: identity)
             .setMethod(method: .GET)

--- a/Sluggo/Models/Managers/InviteManager.swift
+++ b/Sluggo/Models/Managers/InviteManager.swift
@@ -16,7 +16,8 @@ class InviteManager {
         self.identity = identity
     }
 
-    func getInvites(completionHandler: @escaping (Result<[InviteRecord], Error>) -> Void) {
+    // MARK: User Invite Manager
+    func getUserInvites(completionHandler: @escaping (Result<[UserInviteRecord], Error>) -> Void) {
 
         let urlString = identity.baseAddress + InviteManager.urlBase
         let requestBuilder = URLRequestBuilder(url: URL(string: urlString)!)
@@ -24,5 +25,67 @@ class InviteManager {
             .setMethod(method: .GET)
 
         JsonLoader.executeCodableRequest(request: requestBuilder.getRequest(), completionHandler: completionHandler)
+    }
+
+    public func acceptUserInvite(invite: UserInviteRecord, completionHandler: @escaping(Result<Void, Error>) -> Void) {
+
+        let urlString = identity.baseAddress + InviteManager.urlBase + "\(invite.id)/"
+        let requestBuilder = URLRequestBuilder(url: URL(string: urlString)!)
+            .setMethod(method: .PUT)
+            .setIdentity(identity: self.identity)
+
+        JsonLoader.executeEmptyRequest(request: requestBuilder.getRequest(), completionHandler: completionHandler)
+
+    }
+
+    public func rejectUserInvite(invite: UserInviteRecord, completionHandler: @escaping(Result<Void, Error>) -> Void) {
+
+        let urlString = identity.baseAddress + InviteManager.urlBase + "\(invite.id)/"
+        let requestBuilder = URLRequestBuilder(url: URL(string: urlString)!)
+            .setMethod(method: .DELETE)
+            .setIdentity(identity: self.identity)
+
+        JsonLoader.executeEmptyRequest(request: requestBuilder.getRequest(), completionHandler: completionHandler)
+
+    }
+
+    // MARK: Team Invite Manager
+    func getTeamInvites(page: Int,
+                        completionHandler: @escaping (Result<PaginatedList<TeamInviteRecord>, Error>) -> Void) {
+
+        let urlString = identity.baseAddress + TeamManager.urlBase + "\(identity.team!.id)/" + "invites/"
+        let requestBuilder = URLRequestBuilder(url: URL(string: urlString)!)
+            .setIdentity(identity: identity)
+            .setMethod(method: .GET)
+
+        JsonLoader.executeCodableRequest(request: requestBuilder.getRequest(), completionHandler: completionHandler)
+    }
+
+    func addTeamInvite(user: UserRecord, completionHandler: @escaping(Result<Void, Error>) -> Void) {
+
+        let urlString = identity.baseAddress + TeamManager.urlBase + "\(identity.team!.id)/" + "invites/"
+
+        guard let body = JsonLoader.encode(object: user) else {
+            let errorMessage = "Failed to serialize ticket JSON for addTeamInvite in InviteManager"
+            completionHandler(.failure(Exception.runtimeError(message: errorMessage)))
+            return
+        }
+
+        let requestBuilder = URLRequestBuilder(url: URL(string: urlString)!)
+            .setIdentity(identity: identity)
+            .setData(data: body)
+            .setMethod(method: .POST)
+
+        JsonLoader.executeEmptyRequest(request: requestBuilder.getRequest(), completionHandler: completionHandler)
+    }
+
+    func deleteTeamInvite(invite: UserInviteRecord, completionHandler: @escaping(Result<Void, Error>) -> Void) {
+
+        let urlString = identity.baseAddress + TeamManager.urlBase + "\(identity.team!.id)/" + "invites/"
+        let requestBuilder = URLRequestBuilder(url: URL(string: urlString)!)
+            .setIdentity(identity: identity)
+            .setMethod(method: .GET)
+
+        JsonLoader.executeEmptyRequest(request: requestBuilder.getRequest(), completionHandler: completionHandler)
     }
 }

--- a/Sluggo/Models/Managers/InviteManager.swift
+++ b/Sluggo/Models/Managers/InviteManager.swift
@@ -1,0 +1,29 @@
+//
+//  InviteManager.swift
+//  Sluggo
+//
+//  Created by Troy on 5/31/21.
+//
+
+import Foundation
+
+class InviteManager: TeamPaginatedListable {
+
+    static let urlBase = "api/teams/"
+    private var identity: AppIdentity
+
+    init(identity: AppIdentity) {
+        self.identity = identity
+    }
+
+    func listFromTeams(page: Int, completionHandler: @escaping (Result<PaginatedList<TeamRecord>, Error>) -> Void) {
+
+        let urlString = identity.baseAddress + TeamManager.urlBase + "\(identity.team!.id)"
+            + "/invites/" + "?page=\(page)"
+        let requestBuilder = URLRequestBuilder(url: URL(string: urlString)!)
+            .setIdentity(identity: identity)
+            .setMethod(method: .GET)
+
+        JsonLoader.executeCodableRequest(request: requestBuilder.getRequest(), completionHandler: completionHandler)
+    }
+}

--- a/Sluggo/Storyboards/Admin/Admin.storyboard
+++ b/Sluggo/Storyboards/Admin/Admin.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Nfn-vq-Q7A">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Nfn-vq-Q7A">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,11 +18,11 @@
                         <sections>
                             <tableViewSection id="PAM-yX-gbw">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="yIb-xH-MDq" detailTextLabel="qYd-z5-mIU" style="IBUITableViewCellStyleSubtitle" id="N87-9o-hws">
-                                        <rect key="frame" x="0.0" y="24.5" width="414" height="43.5"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="yIb-xH-MDq" detailTextLabel="qYd-z5-mIU" style="IBUITableViewCellStyleSubtitle" id="N87-9o-hws">
+                                        <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="N87-9o-hws" id="xlv-ZQ-Oco">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Users" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="yIb-xH-MDq">
@@ -32,8 +32,8 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Manage users and roles" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qYd-z5-mIU">
-                                                    <rect key="frame" x="20" y="22.5" width="125" height="13.5"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Manage Users and Roles" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="qYd-z5-mIU">
+                                                    <rect key="frame" x="20" y="22.5" width="129.5" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <nil key="textColor"/>
@@ -45,11 +45,11 @@
                                             <segue destination="XMy-yX-PQZ" kind="show" identifier="createUsersList" destinationCreationSelector="createUsersList:" id="p9F-N2-shF"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="r7v-WH-Cu9" detailTextLabel="Anm-hW-DmG" style="IBUITableViewCellStyleSubtitle" id="BgD-BG-lAA">
-                                        <rect key="frame" x="0.0" y="68" width="414" height="43.5"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="r7v-WH-Cu9" detailTextLabel="Anm-hW-DmG" style="IBUITableViewCellStyleSubtitle" id="BgD-BG-lAA">
+                                        <rect key="frame" x="0.0" y="71.5" width="414" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="BgD-BG-lAA" id="PH6-DU-EFP">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Tags" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="r7v-WH-Cu9">
@@ -59,8 +59,8 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Manage Ticket tags" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Anm-hW-DmG">
-                                                    <rect key="frame" x="20" y="22.5" width="103" height="13.5"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Manage Ticket Tags" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Anm-hW-DmG">
+                                                    <rect key="frame" x="20" y="22.5" width="105" height="13.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                                     <nil key="textColor"/>
@@ -70,6 +70,33 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="9Is-y3-2me" kind="show" destinationCreationSelector="createTagsList:" id="Pbf-UO-Cyv"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="QG3-Gz-Ky0" detailTextLabel="XaY-Eg-s84" style="IBUITableViewCellStyleSubtitle" id="dKi-Wo-2dN">
+                                        <rect key="frame" x="0.0" y="115" width="414" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dKi-Wo-2dN" id="iPE-QN-Dby">
+                                            <rect key="frame" x="0.0" y="0.0" width="383" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Invites" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="QG3-Gz-Ky0">
+                                                    <rect key="frame" x="20" y="6" width="37" height="14.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Manage Team Invites" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="XaY-Eg-s84">
+                                                    <rect key="frame" x="20" y="22.5" width="110.5" height="13.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="F2m-CL-hmY" kind="show" destinationCreationSelector="createInviteList:" id="2ls-xL-ePP"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -98,7 +125,7 @@
                             <tableViewSection headerTitle="User Roles" id="n1J-v6-Vi6">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="NaF-b5-xQ0" customClass="TicketTagTableViewCell" customModule="Sluggo" customModuleProvider="target">
-                                        <rect key="frame" x="20" y="49.5" width="374" height="43.5"/>
+                                        <rect key="frame" x="20" y="55.5" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="NaF-b5-xQ0" id="oqJ-UC-03O">
                                             <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
@@ -119,7 +146,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="wdh-32-WB1" customClass="TicketTagTableViewCell" customModule="Sluggo" customModuleProvider="target">
-                                        <rect key="frame" x="20" y="93" width="374" height="43.5"/>
+                                        <rect key="frame" x="20" y="99" width="374" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wdh-32-WB1" id="INS-L1-LXh">
                                             <rect key="frame" x="0.0" y="0.0" width="374" height="43.5"/>
@@ -171,7 +198,17 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zwr-jF-Bex" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1824" y="355"/>
+            <point key="canvasLocation" x="1858" y="117"/>
+        </scene>
+        <!--AdminInviteViewController-->
+        <scene sceneID="MBb-XI-rus">
+            <objects>
+                <viewControllerPlaceholder storyboardName="AdminInvite" referencedIdentifier="AdminInviteViewController" id="F2m-CL-hmY" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="ldf-hT-jTO"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="8Ix-sm-gu3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1859" y="344"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="URV-lv-mtA">

--- a/Sluggo/Storyboards/Admin/AdminInvite.storyboard
+++ b/Sluggo/Storyboards/Admin/AdminInvite.storyboard
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Invites-->
+        <scene sceneID="YLo-ty-GBX">
+            <objects>
+                <tableViewController storyboardIdentifier="AdminInviteViewController" id="QTl-Lo-xxr" customClass="AdminInviteViewController" customModule="Sluggo" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="gab-at-nJo">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="TeamInviteCell" textLabel="elV-Jo-g9y" detailTextLabel="0gD-3L-pyu" style="IBUITableViewCellStyleValue1" id="fN2-rn-82T">
+                                <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fN2-rn-82T" id="ys2-KB-2Cu">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="elV-Jo-g9y">
+                                            <rect key="frame" x="20" y="12" width="33" height="20.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="0gD-3L-pyu">
+                                            <rect key="frame" x="350" y="12" width="44" height="20.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="QTl-Lo-xxr" id="u8i-r0-Ecm"/>
+                            <outlet property="delegate" destination="QTl-Lo-xxr" id="8HW-zG-OIA"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Invites" id="Dgn-uP-9Mq">
+                        <barButtonItem key="rightBarButtonItem" title="Add" image="plus" catalog="system" id="2Cq-kS-CgJ">
+                            <connections>
+                                <action selector="addInvite:" destination="QTl-Lo-xxr" id="b7b-uh-B2h"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="irP-tJ-WBK" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="768" y="188"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="IUE-7X-gWO">
+            <objects>
+                <navigationController storyboardIdentifier="AdminInviteNavController" id="qQU-qS-m2v" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="mBd-Jc-DL9">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="QTl-Lo-xxr" kind="relationship" relationship="rootViewController" id="jB6-sO-ZeY"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="8R6-SK-Ouu" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-122" y="188"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="plus" catalog="system" width="128" height="113"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Sluggo/Storyboards/Main.storyboard
+++ b/Sluggo/Storyboards/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Mda-Hn-Fdu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Mda-Hn-Fdu">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -170,7 +170,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="SLGSidebarCell" textLabel="Xed-fS-leo" rowHeight="62" style="IBUITableViewCellStyleDefault" id="c6C-7Z-RD9" customClass="TeamTableViewCell" customModule="Sluggo" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="24.333333969116211" width="390" height="62"/>
+                                <rect key="frame" x="0.0" y="28" width="390" height="62"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="c6C-7Z-RD9" id="TFn-f1-Eue">
                                     <rect key="frame" x="0.0" y="0.0" width="390" height="62"/>
@@ -216,7 +216,7 @@
                                 <rect key="frame" x="0.0" y="24" width="390" height="46"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Teams" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ehp-J6-oju">
-                                        <rect key="frame" x="8" y="2" width="70.333333333333329" height="32"/>
+                                        <rect key="frame" x="8" y="2" width="78.666666666666671" height="32"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>

--- a/Sluggo/Storyboards/Main.storyboard
+++ b/Sluggo/Storyboards/Main.storyboard
@@ -165,7 +165,7 @@
             <objects>
                 <tableViewController storyboardIdentifier="TeamSelect" id="6JP-5O-LNy" customClass="TeamTableViewController" customModule="Sluggo" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="k0U-Dp-z3Q">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="673"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="695"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
@@ -192,77 +192,63 @@
                             <outlet property="delegate" destination="6JP-5O-LNy" id="jW3-b5-AgP"/>
                         </connections>
                     </tableView>
+                    <toolbarItems/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ZY0-VO-EJL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6057" y="-359"/>
+            <point key="canvasLocation" x="5895" y="-344"/>
         </scene>
         <!--Team Selector Container View Controller-->
         <scene sceneID="Rmd-hI-BYc">
             <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="DyB-vH-6LV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <viewController storyboardIdentifier="TableViewContainer" id="rGb-An-tKe" customClass="TeamSelectorContainerViewController" customModule="Sluggo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Eze-HK-nVO">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="790"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4nR-dn-Ih4">
-                                <rect key="frame" x="0.0" y="78" width="390" height="673"/>
+                                <rect key="frame" x="0.0" y="56" width="390" height="695"/>
                                 <connections>
                                     <segue destination="6JP-5O-LNy" kind="embed" id="Yx7-MO-wXK"/>
                                 </connections>
                             </containerView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MSw-Vx-lxb">
-                                <rect key="frame" x="0.0" y="24" width="390" height="46"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Teams" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ehp-J6-oju">
-                                        <rect key="frame" x="8" y="2" width="78.666666666666671" height="32"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QMb-3q-4Z8">
-                                        <rect key="frame" x="357" y="6" width="25" height="24"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="25" id="9co-2D-ewI"/>
-                                            <constraint firstAttribute="height" constant="24" id="lRj-IX-VFF"/>
-                                        </constraints>
-                                        <connections>
-                                            <action selector="didCancel:" destination="rGb-An-tKe" eventType="touchUpInside" id="tr8-iJ-4QF"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <constraints>
-                                    <constraint firstItem="ehp-J6-oju" firstAttribute="leading" secondItem="MSw-Vx-lxb" secondAttribute="leadingMargin" id="Bf5-Qs-lqo"/>
-                                    <constraint firstItem="ehp-J6-oju" firstAttribute="top" secondItem="MSw-Vx-lxb" secondAttribute="top" constant="2" id="Cli-th-hYr"/>
-                                    <constraint firstItem="QMb-3q-4Z8" firstAttribute="trailing" secondItem="MSw-Vx-lxb" secondAttribute="trailingMargin" id="PdH-7b-IxJ"/>
-                                    <constraint firstItem="QMb-3q-4Z8" firstAttribute="centerY" secondItem="ehp-J6-oju" secondAttribute="centerY" id="rMY-hT-450"/>
-                                    <constraint firstItem="QMb-3q-4Z8" firstAttribute="top" secondItem="MSw-Vx-lxb" secondAttribute="top" constant="6" id="xaO-sw-hLK"/>
-                                </constraints>
-                            </view>
+                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Szf-mh-qem">
+                                <rect key="frame" x="0.0" y="0.0" width="390" height="56"/>
+                                <items>
+                                    <navigationItem title="Teams" id="mIu-wx-cEX">
+                                        <barButtonItem key="leftBarButtonItem" title="Cancel" id="q4K-ZG-KM8">
+                                            <connections>
+                                                <action selector="didCancel:" destination="rGb-An-tKe" id="pgb-fP-CPr"/>
+                                            </connections>
+                                        </barButtonItem>
+                                        <barButtonItem key="rightBarButtonItem" title="Invites" id="8ex-Vd-6eV">
+                                            <connections>
+                                                <action selector="showPendingInvites:" destination="rGb-An-tKe" id="yPV-LZ-n8V"/>
+                                            </connections>
+                                        </barButtonItem>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="sU3-8g-FUq"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="4nR-dn-Ih4" firstAttribute="top" secondItem="Eze-HK-nVO" secondAttribute="top" constant="78" id="7gm-fV-scn"/>
-                            <constraint firstItem="MSw-Vx-lxb" firstAttribute="top" secondItem="sU3-8g-FUq" secondAttribute="top" constant="24" id="Nda-wb-dt3"/>
+                            <constraint firstItem="4nR-dn-Ih4" firstAttribute="top" secondItem="Eze-HK-nVO" secondAttribute="top" constant="56" id="7gm-fV-scn"/>
+                            <constraint firstItem="Szf-mh-qem" firstAttribute="leading" secondItem="sU3-8g-FUq" secondAttribute="leading" id="BQJ-gu-Pl4"/>
+                            <constraint firstItem="Szf-mh-qem" firstAttribute="trailing" secondItem="sU3-8g-FUq" secondAttribute="trailing" id="Ddw-jm-KoW"/>
                             <constraint firstItem="4nR-dn-Ih4" firstAttribute="leading" secondItem="sU3-8g-FUq" secondAttribute="leading" id="UaY-5y-FCr"/>
+                            <constraint firstItem="Szf-mh-qem" firstAttribute="top" secondItem="sU3-8g-FUq" secondAttribute="top" id="bt5-xv-OeR"/>
                             <constraint firstItem="sU3-8g-FUq" firstAttribute="bottom" secondItem="4nR-dn-Ih4" secondAttribute="bottom" constant="5" id="dHm-Ag-YP0"/>
                             <constraint firstItem="4nR-dn-Ih4" firstAttribute="trailing" secondItem="sU3-8g-FUq" secondAttribute="trailing" id="dhk-qE-WJ6"/>
-                            <constraint firstItem="4nR-dn-Ih4" firstAttribute="top" secondItem="MSw-Vx-lxb" secondAttribute="bottom" constant="8" symbolic="YES" id="gmY-4J-eJf"/>
-                            <constraint firstItem="MSw-Vx-lxb" firstAttribute="trailing" secondItem="sU3-8g-FUq" secondAttribute="trailing" id="mzO-ck-2uQ"/>
-                            <constraint firstItem="MSw-Vx-lxb" firstAttribute="leading" secondItem="sU3-8g-FUq" secondAttribute="leading" id="xYl-F3-GsO"/>
                         </constraints>
                     </view>
                     <modalPageSheetSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-                    <connections>
-                        <outlet property="cancelButton" destination="QMb-3q-4Z8" id="SCw-Ud-ElF"/>
-                    </connections>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="DyB-vH-6LV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4990.7692307692305" y="-359.00473933649289"/>
+            <point key="canvasLocation" x="4829" y="-343"/>
         </scene>
         <!--Root-->
         <scene sceneID="Oaf-ww-D71">
@@ -273,6 +259,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="PMQ-JX-4wg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="4525" y="93"/>
+        </scene>
+        <!--pendingInvites-->
+        <scene sceneID="NiN-EJ-mdy">
+            <objects>
+                <viewControllerPlaceholder storyboardName="PendingInvites" referencedIdentifier="pendingInvites" id="QEI-B2-xuE" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="pFR-YU-R1b" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="6595" y="-343"/>
         </scene>
     </scenes>
     <resources>

--- a/Sluggo/Storyboards/Main.storyboard
+++ b/Sluggo/Storyboards/Main.storyboard
@@ -263,7 +263,7 @@
         <!--pendingInvites-->
         <scene sceneID="NiN-EJ-mdy">
             <objects>
-                <viewControllerPlaceholder storyboardName="PendingInvites" referencedIdentifier="pendingInvites" id="QEI-B2-xuE" sceneMemberID="viewController"/>
+                <viewControllerPlaceholder storyboardIdentifier="pendingInvites" storyboardName="PendingInvites" referencedIdentifier="pendingInvites" id="QEI-B2-xuE" sceneMemberID="viewController"/>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pFR-YU-R1b" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="6595" y="-343"/>

--- a/Sluggo/Storyboards/PendingInvites.storyboard
+++ b/Sluggo/Storyboards/PendingInvites.storyboard
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Pending Invites-->
+        <scene sceneID="JQZ-R2-Zc7">
+            <objects>
+                <tableViewController id="J7t-uV-EQA" customClass="PendingInvitesViewController" customModule="Sluggo" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="45" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="T72-92-ffa">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationLevel="1" indentationWidth="10" reuseIdentifier="pInviteCell" rowHeight="44" id="pyK-ed-07x" customClass="InviteTableCell" customModule="Sluggo" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="28" width="414" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pyK-ed-07x" id="XaT-gg-Tsn">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LWK-vF-6ni">
+                                            <rect key="frame" x="350" y="0.0" width="64" height="44"/>
+                                            <color key="backgroundColor" systemColor="systemRedColor"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="64" id="Hvv-uh-i6G"/>
+                                                <constraint firstAttribute="width" constant="64" id="OCk-WV-P4W"/>
+                                            </constraints>
+                                            <state key="normal" title="Reject">
+                                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </state>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Ec-PB-KvF">
+                                            <rect key="frame" x="286" y="0.0" width="64" height="44"/>
+                                            <color key="backgroundColor" systemColor="systemBlueColor"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="64" id="P3k-bv-Iyl"/>
+                                            </constraints>
+                                            <state key="normal" title="Accept">
+                                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </state>
+                                        </button>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="LWK-vF-6ni" secondAttribute="bottom" id="A14-FJ-2Le"/>
+                                        <constraint firstItem="LWK-vF-6ni" firstAttribute="leading" secondItem="8Ec-PB-KvF" secondAttribute="trailing" id="frR-gy-oCS"/>
+                                        <constraint firstItem="8Ec-PB-KvF" firstAttribute="top" secondItem="XaT-gg-Tsn" secondAttribute="top" id="ha0-qL-uZX"/>
+                                        <constraint firstAttribute="trailing" secondItem="LWK-vF-6ni" secondAttribute="trailing" id="n78-oF-vYe"/>
+                                        <constraint firstItem="LWK-vF-6ni" firstAttribute="top" secondItem="XaT-gg-Tsn" secondAttribute="top" id="tPg-1J-k7e"/>
+                                        <constraint firstAttribute="bottom" secondItem="8Ec-PB-KvF" secondAttribute="bottom" id="wb2-86-1wf"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="acceptButton" destination="8Ec-PB-KvF" id="eVA-r0-htf"/>
+                                    <outlet property="rejectButton" destination="LWK-vF-6ni" id="hEv-WH-3Gf"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="J7t-uV-EQA" id="CjP-Tb-R24"/>
+                            <outlet property="delegate" destination="J7t-uV-EQA" id="ysC-bh-Q5q"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Pending Invites" id="Vt0-qm-ZHx">
+                        <barButtonItem key="leftBarButtonItem" title="Close" id="ufR-MP-33Z">
+                            <connections>
+                                <action selector="backButton:" destination="J7t-uV-EQA" id="LVo-Jo-Fth"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Okk-f2-MWT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="88.405797101449281" y="-732.58928571428567"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="R09-Ck-t38">
+            <objects>
+                <navigationController storyboardIdentifier="pendingInvites" id="fdh-m1-1oK" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="0Nn-gf-U7w">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="J7t-uV-EQA" kind="relationship" relationship="rootViewController" id="qAa-Et-V6K"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="FOH-lf-Dto" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-801" y="-732"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Sluggo/Storyboards/PendingInvites.storyboard
+++ b/Sluggo/Storyboards/PendingInvites.storyboard
@@ -11,12 +11,12 @@
         <scene sceneID="JQZ-R2-Zc7">
             <objects>
                 <tableViewController id="J7t-uV-EQA" customClass="PendingInvitesViewController" customModule="Sluggo" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="45" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="T72-92-ffa">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="45" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="T72-92-ffa">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationLevel="1" indentationWidth="10" reuseIdentifier="pInviteCell" rowHeight="44" id="pyK-ed-07x" customClass="InviteTableCell" customModule="Sluggo" customModuleProvider="target">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="gray" indentationLevel="1" indentationWidth="10" reuseIdentifier="pInviteCell" rowHeight="44" id="pyK-ed-07x" customClass="InviteTableCell" customModule="Sluggo" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pyK-ed-07x" id="XaT-gg-Tsn">

--- a/Sluggo/Storyboards/Sidebar.storyboard
+++ b/Sluggo/Storyboards/Sidebar.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="z3Q-wy-zSO">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="z3Q-wy-zSO">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,14 +18,14 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" reuseIdentifier="SLGSidebarCell" textLabel="73u-VP-0wj" style="IBUITableViewCellStyleDefault" id="t4U-f1-qzY" customClass="TeamTableViewCell" customModule="Sluggo" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="24.5" width="280" height="43.5"/>
+                                <rect key="frame" x="0.0" y="28" width="280" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="t4U-f1-qzY" id="sBI-5J-NPm" customClass="TeamTableViewCell" customModule="Sluggo" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="243.5" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="240" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="73u-VP-0wj">
-                                            <rect key="frame" x="16" y="0.0" width="219.5" height="43.5"/>
+                                            <rect key="frame" x="16" y="0.0" width="216" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -46,11 +46,81 @@
                                 <action selector="doLogOutAction:" destination="PJK-Xs-1jr" id="ees-yu-euF"/>
                             </connections>
                         </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="Invites" id="DXd-cY-g2q">
+                            <connections>
+                                <action selector="showPendingInvites:" destination="PJK-Xs-1jr" id="XNG-hV-8xX"/>
+                            </connections>
+                        </barButtonItem>
                     </navigationItem>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="HKS-Hy-anX" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="913.04347826086962" y="63.616071428571423"/>
+        </scene>
+        <!--Pending Invites-->
+        <scene sceneID="JQZ-R2-Zc7">
+            <objects>
+                <tableViewController id="J7t-uV-EQA" customClass="PendingInvitesViewController" customModule="Sluggo" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="T72-92-ffa">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="pInviteCell" id="pyK-ed-07x">
+                                <rect key="frame" x="0.0" y="28" width="414" height="30.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pyK-ed-07x" id="XaT-gg-Tsn">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="30.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Ec-PB-KvF">
+                                            <rect key="frame" x="322" y="0.0" width="92" height="30.5"/>
+                                            <color key="backgroundColor" systemColor="systemBlueColor"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="92" id="nlc-PW-mEa"/>
+                                            </constraints>
+                                            <state key="normal" title="Accept">
+                                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="acceptInvite:" destination="J7t-uV-EQA" eventType="touchUpInside" id="TWd-hb-9CG"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstAttribute="bottom" secondItem="8Ec-PB-KvF" secondAttribute="bottom" id="0Tl-oL-aiE"/>
+                                        <constraint firstItem="8Ec-PB-KvF" firstAttribute="top" secondItem="XaT-gg-Tsn" secondAttribute="top" id="Vpd-Gw-bRc"/>
+                                        <constraint firstAttribute="trailing" secondItem="8Ec-PB-KvF" secondAttribute="trailing" id="hfY-oL-vfP"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="J7t-uV-EQA" id="CjP-Tb-R24"/>
+                            <outlet property="delegate" destination="J7t-uV-EQA" id="ysC-bh-Q5q"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Pending Invites" id="Vt0-qm-ZHx"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Okk-f2-MWT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="89" y="-732"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="R09-Ck-t38">
+            <objects>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="FOH-lf-Dto" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <navigationController storyboardIdentifier="pendingInvites" id="fdh-m1-1oK" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="0Nn-gf-U7w">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="J7t-uV-EQA" kind="relationship" relationship="rootViewController" id="qAa-Et-V6K"/>
+                    </connections>
+                </navigationController>
+            </objects>
+            <point key="canvasLocation" x="-801" y="-732"/>
         </scene>
         <!--Sluggo Sidebar Container View Controller-->
         <scene sceneID="qeb-n7-jUm">
@@ -128,6 +198,9 @@
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Sluggo/Storyboards/Sidebar.storyboard
+++ b/Sluggo/Storyboards/Sidebar.storyboard
@@ -73,11 +73,24 @@
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="30.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Ec-PB-KvF">
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LWK-vF-6ni">
                                             <rect key="frame" x="322" y="0.0" width="92" height="30.5"/>
+                                            <color key="backgroundColor" systemColor="systemRedColor"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="92" id="XLO-AC-U3v"/>
+                                            </constraints>
+                                            <state key="normal" title="Reject">
+                                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="rejectInvite:" destination="J7t-uV-EQA" eventType="touchUpInside" id="gUW-oe-FJP"/>
+                                            </connections>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Ec-PB-KvF">
+                                            <rect key="frame" x="230" y="0.0" width="92" height="30.5"/>
                                             <color key="backgroundColor" systemColor="systemBlueColor"/>
                                             <constraints>
-                                                <constraint firstAttribute="width" constant="92" id="nlc-PW-mEa"/>
+                                                <constraint firstAttribute="width" constant="92" id="Z15-fn-8CI"/>
                                             </constraints>
                                             <state key="normal" title="Accept">
                                                 <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -88,9 +101,12 @@
                                         </button>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstAttribute="bottom" secondItem="8Ec-PB-KvF" secondAttribute="bottom" id="0Tl-oL-aiE"/>
-                                        <constraint firstItem="8Ec-PB-KvF" firstAttribute="top" secondItem="XaT-gg-Tsn" secondAttribute="top" id="Vpd-Gw-bRc"/>
-                                        <constraint firstAttribute="trailing" secondItem="8Ec-PB-KvF" secondAttribute="trailing" id="hfY-oL-vfP"/>
+                                        <constraint firstAttribute="bottom" secondItem="LWK-vF-6ni" secondAttribute="bottom" id="A14-FJ-2Le"/>
+                                        <constraint firstItem="LWK-vF-6ni" firstAttribute="leading" secondItem="8Ec-PB-KvF" secondAttribute="trailing" id="frR-gy-oCS"/>
+                                        <constraint firstItem="8Ec-PB-KvF" firstAttribute="top" secondItem="XaT-gg-Tsn" secondAttribute="top" id="ha0-qL-uZX"/>
+                                        <constraint firstAttribute="trailing" secondItem="LWK-vF-6ni" secondAttribute="trailing" id="n78-oF-vYe"/>
+                                        <constraint firstItem="LWK-vF-6ni" firstAttribute="top" secondItem="XaT-gg-Tsn" secondAttribute="top" id="tPg-1J-k7e"/>
+                                        <constraint firstAttribute="bottom" secondItem="8Ec-PB-KvF" secondAttribute="bottom" id="wb2-86-1wf"/>
                                     </constraints>
                                 </tableViewCellContentView>
                             </tableViewCell>
@@ -100,7 +116,13 @@
                             <outlet property="delegate" destination="J7t-uV-EQA" id="ysC-bh-Q5q"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Pending Invites" id="Vt0-qm-ZHx"/>
+                    <navigationItem key="navigationItem" title="Pending Invites" id="Vt0-qm-ZHx">
+                        <barButtonItem key="leftBarButtonItem" title="Back" id="ufR-MP-33Z">
+                            <connections>
+                                <action selector="backButton:" destination="J7t-uV-EQA" id="LVo-Jo-Fth"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Okk-f2-MWT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -109,7 +131,6 @@
         <!--Navigation Controller-->
         <scene sceneID="R09-Ck-t38">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="FOH-lf-Dto" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
                 <navigationController storyboardIdentifier="pendingInvites" id="fdh-m1-1oK" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="0Nn-gf-U7w">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
@@ -119,6 +140,7 @@
                         <segue destination="J7t-uV-EQA" kind="relationship" relationship="rootViewController" id="qAa-Et-V6K"/>
                     </connections>
                 </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="FOH-lf-Dto" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-801" y="-732"/>
         </scene>
@@ -201,6 +223,9 @@
         </systemColor>
         <systemColor name="systemBlueColor">
             <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemRedColor">
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Sluggo/Storyboards/Sidebar.storyboard
+++ b/Sluggo/Storyboards/Sidebar.storyboard
@@ -61,43 +61,38 @@
         <scene sceneID="JQZ-R2-Zc7">
             <objects>
                 <tableViewController id="J7t-uV-EQA" customClass="PendingInvitesViewController" customModule="Sluggo" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="T72-92-ffa">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="45" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="T72-92-ffa">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="pInviteCell" id="pyK-ed-07x">
-                                <rect key="frame" x="0.0" y="28" width="414" height="30.5"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationLevel="1" indentationWidth="10" reuseIdentifier="pInviteCell" rowHeight="44" id="pyK-ed-07x" customClass="InviteTableCell" customModule="Sluggo" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pyK-ed-07x" id="XaT-gg-Tsn">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="30.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LWK-vF-6ni">
-                                            <rect key="frame" x="322" y="0.0" width="92" height="30.5"/>
+                                            <rect key="frame" x="350" y="0.0" width="64" height="44"/>
                                             <color key="backgroundColor" systemColor="systemRedColor"/>
                                             <constraints>
-                                                <constraint firstAttribute="width" constant="92" id="XLO-AC-U3v"/>
+                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="64" id="Hvv-uh-i6G"/>
+                                                <constraint firstAttribute="width" constant="64" id="OCk-WV-P4W"/>
                                             </constraints>
                                             <state key="normal" title="Reject">
                                                 <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </state>
-                                            <connections>
-                                                <action selector="rejectInvite:" destination="J7t-uV-EQA" eventType="touchUpInside" id="gUW-oe-FJP"/>
-                                            </connections>
                                         </button>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Ec-PB-KvF">
-                                            <rect key="frame" x="230" y="0.0" width="92" height="30.5"/>
+                                            <rect key="frame" x="286" y="0.0" width="64" height="44"/>
                                             <color key="backgroundColor" systemColor="systemBlueColor"/>
                                             <constraints>
-                                                <constraint firstAttribute="width" constant="92" id="Z15-fn-8CI"/>
+                                                <constraint firstAttribute="width" constant="64" id="P3k-bv-Iyl"/>
                                             </constraints>
                                             <state key="normal" title="Accept">
                                                 <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </state>
-                                            <connections>
-                                                <action selector="acceptInvite:" destination="J7t-uV-EQA" eventType="touchUpInside" id="TWd-hb-9CG"/>
-                                            </connections>
                                         </button>
                                     </subviews>
                                     <constraints>
@@ -109,6 +104,10 @@
                                         <constraint firstAttribute="bottom" secondItem="8Ec-PB-KvF" secondAttribute="bottom" id="wb2-86-1wf"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="acceptButton" destination="8Ec-PB-KvF" id="lEJ-YF-99G"/>
+                                    <outlet property="rejectButton" destination="LWK-vF-6ni" id="hEv-WH-3Gf"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <connections>
@@ -126,7 +125,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Okk-f2-MWT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="89" y="-732"/>
+            <point key="canvasLocation" x="88.405797101449281" y="-732.58928571428567"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="R09-Ck-t38">

--- a/Sluggo/Storyboards/Sidebar.storyboard
+++ b/Sluggo/Storyboards/Sidebar.storyboard
@@ -105,7 +105,7 @@
                                     </constraints>
                                 </tableViewCellContentView>
                                 <connections>
-                                    <outlet property="acceptButton" destination="8Ec-PB-KvF" id="lEJ-YF-99G"/>
+                                    <outlet property="acceptButton" destination="8Ec-PB-KvF" id="eVA-r0-htf"/>
                                     <outlet property="rejectButton" destination="LWK-vF-6ni" id="hEv-WH-3Gf"/>
                                 </connections>
                             </tableViewCell>
@@ -116,7 +116,7 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="Pending Invites" id="Vt0-qm-ZHx">
-                        <barButtonItem key="leftBarButtonItem" title="Back" id="ufR-MP-33Z">
+                        <barButtonItem key="leftBarButtonItem" title="Close" id="ufR-MP-33Z">
                             <connections>
                                 <action selector="backButton:" destination="J7t-uV-EQA" id="LVo-Jo-Fth"/>
                             </connections>

--- a/Sluggo/Storyboards/Sidebar.storyboard
+++ b/Sluggo/Storyboards/Sidebar.storyboard
@@ -57,92 +57,6 @@
             </objects>
             <point key="canvasLocation" x="913.04347826086962" y="63.616071428571423"/>
         </scene>
-        <!--Pending Invites-->
-        <scene sceneID="JQZ-R2-Zc7">
-            <objects>
-                <tableViewController id="J7t-uV-EQA" customClass="PendingInvitesViewController" customModule="Sluggo" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="45" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="T72-92-ffa">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationLevel="1" indentationWidth="10" reuseIdentifier="pInviteCell" rowHeight="44" id="pyK-ed-07x" customClass="InviteTableCell" customModule="Sluggo" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="414" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pyK-ed-07x" id="XaT-gg-Tsn">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LWK-vF-6ni">
-                                            <rect key="frame" x="350" y="0.0" width="64" height="44"/>
-                                            <color key="backgroundColor" systemColor="systemRedColor"/>
-                                            <constraints>
-                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="64" id="Hvv-uh-i6G"/>
-                                                <constraint firstAttribute="width" constant="64" id="OCk-WV-P4W"/>
-                                            </constraints>
-                                            <state key="normal" title="Reject">
-                                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            </state>
-                                        </button>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8Ec-PB-KvF">
-                                            <rect key="frame" x="286" y="0.0" width="64" height="44"/>
-                                            <color key="backgroundColor" systemColor="systemBlueColor"/>
-                                            <constraints>
-                                                <constraint firstAttribute="width" constant="64" id="P3k-bv-Iyl"/>
-                                            </constraints>
-                                            <state key="normal" title="Accept">
-                                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            </state>
-                                        </button>
-                                    </subviews>
-                                    <constraints>
-                                        <constraint firstAttribute="bottom" secondItem="LWK-vF-6ni" secondAttribute="bottom" id="A14-FJ-2Le"/>
-                                        <constraint firstItem="LWK-vF-6ni" firstAttribute="leading" secondItem="8Ec-PB-KvF" secondAttribute="trailing" id="frR-gy-oCS"/>
-                                        <constraint firstItem="8Ec-PB-KvF" firstAttribute="top" secondItem="XaT-gg-Tsn" secondAttribute="top" id="ha0-qL-uZX"/>
-                                        <constraint firstAttribute="trailing" secondItem="LWK-vF-6ni" secondAttribute="trailing" id="n78-oF-vYe"/>
-                                        <constraint firstItem="LWK-vF-6ni" firstAttribute="top" secondItem="XaT-gg-Tsn" secondAttribute="top" id="tPg-1J-k7e"/>
-                                        <constraint firstAttribute="bottom" secondItem="8Ec-PB-KvF" secondAttribute="bottom" id="wb2-86-1wf"/>
-                                    </constraints>
-                                </tableViewCellContentView>
-                                <connections>
-                                    <outlet property="acceptButton" destination="8Ec-PB-KvF" id="eVA-r0-htf"/>
-                                    <outlet property="rejectButton" destination="LWK-vF-6ni" id="hEv-WH-3Gf"/>
-                                </connections>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="J7t-uV-EQA" id="CjP-Tb-R24"/>
-                            <outlet property="delegate" destination="J7t-uV-EQA" id="ysC-bh-Q5q"/>
-                        </connections>
-                    </tableView>
-                    <navigationItem key="navigationItem" title="Pending Invites" id="Vt0-qm-ZHx">
-                        <barButtonItem key="leftBarButtonItem" title="Close" id="ufR-MP-33Z">
-                            <connections>
-                                <action selector="backButton:" destination="J7t-uV-EQA" id="LVo-Jo-Fth"/>
-                            </connections>
-                        </barButtonItem>
-                    </navigationItem>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="Okk-f2-MWT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="88.405797101449281" y="-732.58928571428567"/>
-        </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="R09-Ck-t38">
-            <objects>
-                <navigationController storyboardIdentifier="pendingInvites" id="fdh-m1-1oK" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="0Nn-gf-U7w">
-                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <connections>
-                        <segue destination="J7t-uV-EQA" kind="relationship" relationship="rootViewController" id="qAa-Et-V6K"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="FOH-lf-Dto" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-801" y="-732"/>
-        </scene>
         <!--Sluggo Sidebar Container View Controller-->
         <scene sceneID="qeb-n7-jUm">
             <objects>
@@ -215,16 +129,18 @@
             </objects>
             <point key="canvasLocation" x="2.8985507246376816" y="63.616071428571423"/>
         </scene>
+        <!--pendingInvites-->
+        <scene sceneID="1UC-yM-8nL">
+            <objects>
+                <viewControllerPlaceholder storyboardIdentifier="pendingInvites" storyboardName="PendingInvites" referencedIdentifier="pendingInvites" id="dmU-X5-rhw" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="pdL-sh-8ky" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1693" y="64"/>
+        </scene>
     </scenes>
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemBlueColor">
-            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Sluggo/Storyboards/TeamMembers.storyboard
+++ b/Sluggo/Storyboards/TeamMembers.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="E8f-aG-d2W">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="E8f-aG-d2W">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="MemberCell" textLabel="LHt-IM-yyK" detailTextLabel="AYB-ir-7Tr" style="IBUITableViewCellStyleValue1" id="WSC-FE-HFz">
-                                <rect key="frame" x="0.0" y="24.5" width="414" height="43.5"/>
+                                <rect key="frame" x="0.0" y="28" width="414" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="WSC-FE-HFz" id="n3f-4p-LAd">
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="43.5"/>
@@ -56,7 +56,7 @@
         <scene sceneID="ami-Zl-Jrs">
             <objects>
                 <navigationController id="E8f-aG-d2W" customClass="SluggoNavigationController" customModule="Sluggo" customModuleProvider="target" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Members" image="person.2.fill" catalog="system" id="urg-qZ-4T3"/>
+                    <tabBarItem key="tabBarItem" title="Members" image="person.2" catalog="system" id="urg-qZ-4T3"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="1QG-Aw-Qpg">
                         <rect key="frame" x="0.0" y="44" width="414" height="44"/>
@@ -75,7 +75,7 @@
         </scene>
     </scenes>
     <resources>
-        <image name="person.2.fill" catalog="system" width="128" height="80"/>
+        <image name="person.2" catalog="system" width="128" height="81"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Sluggo/View Controllers/AdminInviteViewController.swift
+++ b/Sluggo/View Controllers/AdminInviteViewController.swift
@@ -25,6 +25,8 @@ class AdminInviteViewController: UITableViewController {
     override func viewDidLoad() {
         self.configureRefreshControl()
         self.handleRefreshAction()
+        NotificationCenter.default.addObserver(self, selector: #selector(handleRefreshAction),
+                                               name: .refreshTeamInvites, object: nil)
 
     }
 

--- a/Sluggo/View Controllers/AdminInviteViewController.swift
+++ b/Sluggo/View Controllers/AdminInviteViewController.swift
@@ -1,0 +1,119 @@
+//
+//  AdminInviteViewController.swift
+//  Sluggo
+//
+//  Created by Troy Ebert on 5/31/21.
+//
+
+import UIKit
+
+class AdminInviteViewController: UITableViewController {
+    var identity: AppIdentity!
+    private var invites: [TagRecord] = []
+    private var isFetching = false
+    private var semaphore = DispatchSemaphore(value: 1)
+
+    required init? (coder: NSCoder, identity: AppIdentity) {
+        self.identity = identity
+        super.init(coder: coder)
+    }
+
+    required init? (coder: NSCoder) {
+        fatalError("Must be initialized with identity")
+    }
+
+    override func viewDidLoad() {
+        self.configureRefreshControl()
+        self.handleRefreshAction()
+
+    }
+
+    func configureRefreshControl() {
+        refreshControl = UIRefreshControl()
+        refreshControl?.addTarget(self, action: #selector(handleRefreshAction), for: .valueChanged)
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return invites.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "TagCell", for: indexPath) as UITableViewCell
+        let tag = self.invites[indexPath.row]
+        cell.textLabel?.text = tag.title
+        cell.detailTextLabel?.text = ""
+
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle,
+                            forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            let aCon = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+            aCon.addAction(UIAlertAction(title: "Delete Tag", style: .destructive, handler: { _ in
+                let manager = TagManager(identity: self.identity)
+                let tag = self.invites[indexPath.row]
+                manager.deleteTag(tag: tag) { result in
+                    self.processResult(result: result) { _ in
+                        DispatchQueue.main.async {
+                            NotificationCenter.default.post(name: .refreshTags, object: self)
+                            NotificationCenter.default.post(name: .refreshTrigger, object: self)
+                        }
+                    }
+                }
+            }))
+            aCon.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+            aCon.popoverPresentationController?.barButtonItem = self.navigationItem.rightBarButtonItem
+            present(aCon, animated: true)
+        }
+    }
+
+    @IBAction func addTagHit(_ sender: Any) {
+        let aCon = UIAlertController(title: "Invite User", message: nil, preferredStyle: .alert)
+        aCon.addTextField { textField in
+            textField.placeholder = "Email"
+        }
+        aCon.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        aCon.addAction(UIAlertAction(title: "Send", style: .default, handler: { _ in
+            let textField = aCon.textFields?[0] ?? nil
+            if let text = textField?.text {
+                let manager = TagManager(identity: self.identity)
+                let tag = WriteTagRecord(title: text)
+                manager.makeTag(tag: tag) { result in
+                    self.processResult(result: result) { _ in
+                        DispatchQueue.main.async {
+                            NotificationCenter.default.post(name: .refreshTags, object: self)
+                        }
+                    }
+                }
+            }
+        }))
+        aCon.popoverPresentationController?.barButtonItem = self.navigationItem.rightBarButtonItem
+        present(aCon, animated: true)
+
+    }
+
+    @objc func handleRefreshAction() {
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.semaphore.wait()
+
+            let onSuccess = { (tags: [TagRecord]) -> Void in
+                self.invites = tags
+            }
+
+            let after = { () -> Void in
+                DispatchQueue.main.async {
+                    self.refreshControl?.endRefreshing()
+                    self.tableView.reloadData()
+                }
+                self.semaphore.signal()
+            }
+
+            let tagManager = TagManager(identity: self.identity)
+            unwindPagination(manager: tagManager, startingPage: 1, onSuccess: onSuccess,
+                             onFailure: self.presentErrorFromMainThread, after: after)
+        }
+
+    }
+}

--- a/Sluggo/View Controllers/AdminTableViewController.swift
+++ b/Sluggo/View Controllers/AdminTableViewController.swift
@@ -46,8 +46,9 @@ class AdminTableViewController: UITableViewController {
         let view = AdminTagViewController(coder: coder, identity: identity)
         return view
     }
-    @IBSegueAction func createInvitesList(_ coder: NSCoder) -> AdminTagViewController? {
-        let view = AdminTagViewController(coder: coder, identity: identity)
+
+    @IBSegueAction func createInviteList(_ coder: NSCoder) -> AdminInviteViewController? {
+        let view = AdminInviteViewController(coder: coder, identity: identity)
         return view
     }
 }

--- a/Sluggo/View Controllers/AdminTableViewController.swift
+++ b/Sluggo/View Controllers/AdminTableViewController.swift
@@ -46,4 +46,8 @@ class AdminTableViewController: UITableViewController {
         let view = AdminTagViewController(coder: coder, identity: identity)
         return view
     }
+    @IBSegueAction func createInvitesList(_ coder: NSCoder) -> AdminTagViewController? {
+        let view = AdminTagViewController(coder: coder, identity: identity)
+        return view
+    }
 }

--- a/Sluggo/View Controllers/PendingInvitesViewController.swift
+++ b/Sluggo/View Controllers/PendingInvitesViewController.swift
@@ -1,0 +1,97 @@
+//
+//  PendingInvitesViewController.swift
+//  Sluggo
+//
+//  Created by Troy Ebert on 5/30/21.
+//
+
+import UIKit
+
+class PendingInvitesViewController: UITableViewController {
+    var identity: AppIdentity!
+    var generateSegueableController: ((AppIdentity, MemberRecord?) -> UIViewController?)?
+    var generateMemberDetail: ((MemberRecord) -> String?)?
+    private var maxNumber: Int = 0
+    private var members: [MemberRecord] = []
+    private var isFetching  = false
+    private var semaphore = DispatchSemaphore(value: 1)
+
+    required init? (coder: NSCoder, identity: AppIdentity) {
+        self.identity = identity
+        super.init(coder: coder)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    override func viewDidLoad() {
+        self.configureRefreshControl()
+        self.handleRefreshAction()
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleRefreshAction),
+                                               name: .refreshMembers, object: nil)
+
+        self.tableView.allowsSelection = (generateSegueableController != nil)
+    }
+
+    func configureRefreshControl() {
+        refreshControl = UIRefreshControl()
+        refreshControl?.addTarget(self, action: #selector(handleRefreshAction), for: .valueChanged)
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return members.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "pInviteCell", for: indexPath) as UITableViewCell
+        let member = self.members[indexPath.row]
+        cell.textLabel?.text = member.owner.username
+        cell.detailTextLabel?.text = generateMemberDetail?(member) ?? ""
+
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        guard let generateController = self.generateSegueableController else { return }
+
+        guard let viewController = generateController(identity, self.members[indexPath.row]) else { return }
+
+        if let navController = self.navigationController {
+            navController.show(viewController, sender: self)
+        } else {
+            self.present(viewController, animated: true, completion: nil)
+        }
+    }
+
+    @objc func handleRefreshAction() {
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            self.semaphore.wait()
+
+            let onSuccess = { (members: [MemberRecord]) -> Void in
+                self.members = members
+            }
+
+            let after = { () -> Void in
+                DispatchQueue.main.async {
+                    self.refreshControl?.endRefreshing()
+                    self.tableView.reloadData()
+                }
+                self.semaphore.signal()
+            }
+
+            let memberManager = MemberManager(identity: self.identity)
+            unwindPagination(manager: memberManager,
+                             startingPage: 1,
+                             onSuccess: onSuccess,
+                             onFailure: self.presentErrorFromMainThread,
+                             after: after)
+        }
+    }
+
+    @IBAction func acceptInvite(_ sender: Any) {
+        print("Accepted!")
+    }
+}

--- a/Sluggo/View Controllers/PendingInvitesViewController.swift
+++ b/Sluggo/View Controllers/PendingInvitesViewController.swift
@@ -28,8 +28,8 @@ class PendingInvitesViewController: UITableViewController {
     override func viewDidLoad() {
         self.configureRefreshControl()
         self.handleRefreshAction()
-
-        self.tableView.allowsSelection = (generateSegueableController != nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleRefreshAction),
+                                               name: .refreshInvites, object: nil)
     }
 
     func configureRefreshControl() {
@@ -46,8 +46,10 @@ class PendingInvitesViewController: UITableViewController {
                 as? InviteTableCell else {fatalError("Could not load InviteTableCell")}
         let inviteeTeam = self.inviteeTeams[indexPath.row]
         cell.textLabel?.text = inviteeTeam.team.name
+
         cell.acceptButton.tag = indexPath.row
         cell.acceptButton.addTarget(self, action: #selector(doAcceptInvitation(sender:)), for: .touchUpInside)
+
         cell.rejectButton.tag = indexPath.row
         cell.rejectButton.addTarget(self, action: #selector(doRejectInvitation(sender:)), for: .touchUpInside)
 
@@ -84,7 +86,8 @@ class PendingInvitesViewController: UITableViewController {
         inviteManager.acceptUserInvite(invite: invite) { result in
             self.processResult(result: result) { _ in
                 DispatchQueue.main.async {
-                    NotificationCenter.default.post(name: .refreshTrigger, object: self)
+                    NotificationCenter.default.post(name: .refreshInvites, object: self)
+                    NotificationCenter.default.post(name: .refreshTeams, object: self)
                     self.navigationController?.popViewController(animated: false)
                 }
             }
@@ -99,7 +102,7 @@ class PendingInvitesViewController: UITableViewController {
         inviteManager.rejectUserInvite(invite: invite) { result in
             self.processResult(result: result) { _ in
                 DispatchQueue.main.async {
-                    NotificationCenter.default.post(name: .refreshTrigger, object: self)
+                    NotificationCenter.default.post(name: .refreshInvites, object: self)
                     self.navigationController?.popViewController(animated: false)
                 }
             }
@@ -109,6 +112,10 @@ class PendingInvitesViewController: UITableViewController {
     @IBAction func backButton(_ sender: Any) {
         self.dismiss(animated: true, completion: nil)
     }
+}
+
+extension Notification.Name {
+    static let refreshInvites = Notification.Name(rawValue: "SLGRefreshInvitesNotification")
 }
 
 // MARK: Invite Table Cell

--- a/Sluggo/View Controllers/PendingInvitesViewController.swift
+++ b/Sluggo/View Controllers/PendingInvitesViewController.swift
@@ -29,9 +29,6 @@ class PendingInvitesViewController: UITableViewController {
         self.configureRefreshControl()
         self.handleRefreshAction()
 
-        refreshControl = UIRefreshControl()
-        refreshControl?.addTarget(self, action: #selector(handleRefreshAction), for: .valueChanged)
-
         self.tableView.allowsSelection = (generateSegueableController != nil)
     }
 
@@ -45,9 +42,10 @@ class PendingInvitesViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "pInviteCell", for: indexPath) as UITableViewCell
+        let cell = tableView.dequeueReusableCell(withIdentifier: "pInviteCell", for: indexPath) as InviteTableCell
         let inviteeTeam = self.inviteeTeams[indexPath.row]
         cell.textLabel?.text = inviteeTeam.team.name
+        cell.acceptButton.tag = indexPath.row
         // cell.detailTextLabel?.text = generateTeamInviteDetail?(inviteeTeam) ?? ""
 
         return cell
@@ -75,13 +73,29 @@ class PendingInvitesViewController: UITableViewController {
         }
     }
 
-    @IBAction func acceptInvite(_ sender: Any) {
+    @objc func doAcceptInvitation() {
         print("Accepted!")
     }
-    @IBAction func rejectInvite(_ sender: Any) {
+
+    @objc func doRejectInvitation() {
         print("Rejected!")
     }
+
     @IBAction func backButton(_ sender: Any) {
         self.dismiss(animated: true, completion: nil)
+    }
+}
+
+class InviteTableCell: UITableViewCell {
+
+    @IBOutlet weak var acceptButton: UIButton!
+    @IBOutlet weak var rejectButton: UIButton!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+            super.setSelected(selected, animated: animated)
     }
 }

--- a/Sluggo/View Controllers/RootViewController.swift
+++ b/Sluggo/View Controllers/RootViewController.swift
@@ -204,7 +204,7 @@ class RootViewController: UIViewController {
          * Modal presentation is *not* susceptible to this, and so does not
          * need to be accounted for here.
          */
-        guard let tabBarControllerVCs = mainTabBarController?.viewControllers
+        guard (mainTabBarController?.viewControllers) != nil
         else { return false } // return false if something goes wrong in determining
 
         let selectedTabVC = self.mainTabBarController?.selectedViewController

--- a/Sluggo/View Controllers/TeamSelectorContainerViewController.swift
+++ b/Sluggo/View Controllers/TeamSelectorContainerViewController.swift
@@ -44,20 +44,14 @@ class TeamSelectorContainerViewController: UIViewController {
             }
         }
     }
-//
-//    @IBSegueAction func launchTeamSelect(_ coder: NSCoder) -> TeamTableViewController? {
-//        let vc = TeamTableViewController(coder: coder)
-//        vc?.identity = self.identity
-//        vc?.completion = { team in
-//            self.identity.team = team
-//            self.dismiss(animated: true, completion: self.completion)
-//        }
-//        vc?.failure = {
-//            self.dismiss(animated: true, completion: self.failure)
-//        }
-//
-//        return vc
-//    }
+    @IBAction func showPendingInvites(_ sender: Any) {
+        if let view = storyboard?.instantiateViewController(identifier: "pendingInvites") {
+            if let child = view.children[0] as? PendingInvitesViewController {
+                child.identity = self.identity
+            }
+            self.present(view, animated: true, completion: nil)
+        }
+    }
     @IBAction func didCancel(_ sender: Any) {
         self.dismiss(animated: true, completion: self.failure)
     }

--- a/Sluggo/View Controllers/TeamTableViewController.swift
+++ b/Sluggo/View Controllers/TeamTableViewController.swift
@@ -20,6 +20,8 @@ class TeamTableViewController: UITableViewController {
     override func viewDidLoad() {
         self.configureRefreshControl()
         self.handleRefreshAction()
+        NotificationCenter.default.addObserver(self, selector: #selector(handleRefreshAction),
+                                               name: .refreshTeams, object: nil)
     }
 
     func configureRefreshControl() {
@@ -96,4 +98,8 @@ class TeamTableViewController: UITableViewController {
             self.present(view, animated: true, completion: nil)
         }
     }
+}
+
+extension Notification.Name {
+    static let refreshTeams = Notification.Name(rawValue: "SLGRefreshTeamsNotification")
 }

--- a/Sluggo/View Controllers/TeamTableViewController.swift
+++ b/Sluggo/View Controllers/TeamTableViewController.swift
@@ -88,4 +88,12 @@ class TeamTableViewController: UITableViewController {
         self.logOutAction?()
     }
 
+    @IBAction func showPendingInvites(_ sender: Any) {
+        if let view = storyboard?.instantiateViewController(identifier: "pendingInvites") {
+            if let child = view.children[0] as? PendingInvitesViewController {
+                child.identity = self.identity
+            }
+            self.present(view, animated: true, completion: nil)
+        }
+    }
 }


### PR DESCRIPTION
Created both sending/deleting invites to users as a team admin and accepting/rejecting invites as a user. To do so a seperate codable and manager were created to handle the JSON responses. 

To access user invites, there is an invite button on the top left nav bar of each team table (located after login and in the sidebar). It presents a modal list with custom cells, each cell containing the current team's invite and a reject and accept button on the left side. Pressing accept will send a put request and refresh the team table underneath. Rejecting will simply delete the invite. 

Team invites is located in the admin tab under the tags cell. For this I recycled Stephan's vc for admin tags and it functions in the same way. It will display a sent invite to a user (per team). To revoke invite, swipe left and press delete. To send an invite, press the plus in the top left of the nav bar, and type in an email. There is some input sanitization but it is mostly handled by the backend.

Other minor changes:
-Changed the members icon to be outline as it matches the style of the other icons better
-Removed an object in the teamSelect UIView and added a navbar, this was necessary for adding an invite button in the initial team list
-Added arrows to the admin list since they are cells that push